### PR TITLE
fix: mitigate geofence flapping

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,8 @@ name: Publish Docker Image
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
@@ -99,6 +101,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=edge,branch=main
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -1,6 +1,7 @@
 package geo
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -50,6 +51,8 @@ func init() {
 	polygonGeofence, _ = polygonCar.GarageDoor.Geofence.(*PolygonGeofence) // type cast geofence interface
 
 	util.Config.Global.OpCooldown = 0
+
+	os.Setenv("GDO_SKIP_FLAP_DELAY", "true") // for testing, skip 1.5s delay after gdo ops meant to prevent spam from flapping
 }
 
 func Test_getEventChangeAction_Circular(t *testing.T) {

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -59,7 +59,13 @@ func formatLevel(level logger.Level) string {
 // 01/02/2006 15:04:05 [LEVEL] Message...
 func (f *CustomFormatter) Format(entry *logger.Entry) ([]byte, error) {
 	// Use the timestamp from the log entry to format it as you like
-	timestamp := entry.Time.Format("01/02/2006 15:04:05")
+	var timestamp string
+	if os.Getenv("DEBUG") == "true" {
+		// include milliseconds for debug
+		timestamp = entry.Time.Format("01/02/2006 15:04:05.000")
+	} else {
+		timestamp = entry.Time.Format("01/02/2006 15:04:05")
+	}
 
 	// Ensure the log level string is always 5 characters
 	paddedLevel := formatLevel(entry.Level)


### PR DESCRIPTION
Because lat and long must be processed for geofence changes individually, it's possible that when crossing geofences, there may be some flapping. In the scenario where a user does not manually define a cooldown or utilize garage status checks, this can cause the app to spam the garage with commands during a brief window.

This adds a base cooldown to allow a full geofence crossing to take place after the first garage command is sent to mitigate the flapping.