### PR TITLE
feat: add homeassistant gdo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A lightweight app that will operate your smart Garage Door Openers (GDOs) based 
 
 ## Supported Smart Garage Door Openers
 * Current
+  * Any [Home Assistant](https://www.home-assistant.io/) Controlled Garage Door Opener
+    * Controlled by proxying commands through Home Assistant
   * [ratgdo](https://paulwieland.github.io/ratgdo/) (MQTT Configuration)
   * Generic MQTT Controlled Smart Garage Door Openers
   * Generic HTTP Controlled Smart Garage Door Openers

--- a/examples/config.circular.homeassistant.yml
+++ b/examples/config.circular.homeassistant.yml
@@ -35,6 +35,7 @@ garage_doors:
           use_tls: false # optional, instructs app to connect to home assistant using tls (defaults to false)
           skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on home assistant
         entity_id: cover.main_door # id for the garage door entity in home assistant, can be found by adding '/config/entities' to the base url in home assistant
+        enable_status_checks: true # set to true if gdo supports garage states (e.g. garage is closed)
     cars: # list of cars that use this garage door
       - teslamate_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
       - teslamate_car_id: 2 # id used for the second vehicle in TeslaMate's MQTT broker

--- a/examples/config.circular.homeassistant.yml
+++ b/examples/config.circular.homeassistant.yml
@@ -1,0 +1,40 @@
+# This is an example config file with all available options and explanations for circular geofence and ratgdo opener types.
+
+## NOTE ##
+# Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
+
+global:
+  teslamate_mqtt_settings: # settings for teslamate's mqtt broker
+    connection:
+      host: localhost # dns, container name, or IP of teslamate's mqtt host
+      port: 1883
+      client_id: tesla-geogdo # optional, arbitrary client name for MQTT connection; must not be the same as any other MQTT client name, will use random uuid if omitted
+      user: mqtt_user # optional, only define if your mqtt broker requires authentication, can also be passed as env var MQTT_USER
+      pass: mqtt_pass # optional, only define if your mqtt broker requires authentication, can also be passed as env var MQTT_PASS
+      use_tls: false # optional, instructs app to connect to mqtt broker using tls (defaults to false)
+      skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on the mqtt broker
+  cooldown: 5 # minutes to wait after operating garage before allowing another garage operation (set to 0 or omit to disable)
+
+garage_doors:
+  - # main garage example
+    geofence: # circular geofence with a center point, open and close distances (radii)
+      type: circular
+      settings:
+        center:
+          lat: 46.19290425661381
+          lng: -123.79965087116439
+        close_distance: .013 # distance in kilometers car must travel away from garage location to close garage door
+        open_distance: .04 # distance in kilometers car must be in range of garage location while traveling closer to it to open garage door
+    opener:
+      type: homeassistant # type of garage door opener to use
+      settings:
+        connection: # connection settings for home assistant
+          host: homeassistant.local # dns, container name, or IP of home assistant
+          port: 8123
+          api_key: long_api_key # api key for home assistant; generate in user profile
+          use_tls: false # optional, instructs app to connect to home assistant using tls (defaults to false)
+          skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on home assistant
+        entity_id: cover.main_door # id for the garage door entity in home assistant, can be found by adding '/config/entities' to the base url in home assistant
+    cars: # list of cars that use this garage door
+      - teslamate_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
+      - teslamate_car_id: 2 # id used for the second vehicle in TeslaMate's MQTT broker

--- a/examples/config.circular.homeassistant.yml
+++ b/examples/config.circular.homeassistant.yml
@@ -1,4 +1,4 @@
-# This is an example config file with all available options and explanations for circular geofence and ratgdo opener types.
+# This is an example config file with all available options and explanations for circular geofence and homeassistant opener types.
 
 ## NOTE ##
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently

--- a/examples/config.polygon.http.yml
+++ b/examples/config.polygon.http.yml
@@ -63,6 +63,9 @@ garage_doors:
           pass: pass # optional if basic auth is required
         status:
             endpoint: /status # optional, GET endpoint to retrieve current door status; expects simple return values like `open` or `closed`
+            headers: # optional, list of headers, each must be surrounded by single quotes
+              - 'Authorization: Bearer long_api_key' # example header
+              - 'Content-Type: application/json' # example header
         commands:
           # /command endpoint with a body to indicate the command type
           - name: open # name of command
@@ -72,6 +75,9 @@ garage_doors:
             required_start_state: closed # optional; if status endpoint is available, require this starting state to execute this command
             required_finish_state: open # optional; if status endpoint is available, require this stop state to confirm successful command execution
             timeout: 25 # optional, seconds to wait for garage door operation to complete if watching the status (default 30)
+            headers: # optional, list of headers, each must be surrounded by single quotes
+              - 'Authorization: Bearer long_api_key' # example header
+              - 'Content-Type: application/json' # example header
           # /close endpoint with no body required, as the endpoint /close defines the type
           - name: close
             endpoint: /close
@@ -80,5 +86,8 @@ garage_doors:
             required_start_state: open
             required_finish_state: closed
             timeout: 25
+            headers: # optional, list of headers, each must be surrounded by single quotes
+              - 'Authorization: Bearer long_api_key' # example header
+              - 'Content-Type: application/json' # example header
     cars:
       - teslamate_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker

--- a/internal/gdo/gdo.go
+++ b/internal/gdo/gdo.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/brchri/tesla-geogdo/internal/gdo/homeassistant"
 	"github.com/brchri/tesla-geogdo/internal/gdo/http"
 	"github.com/brchri/tesla-geogdo/internal/gdo/mqtt"
 	"github.com/brchri/tesla-geogdo/internal/gdo/ratgdo"
@@ -29,6 +30,8 @@ func Initialize(config map[string]interface{}) (GDO, error) {
 		return mqtt.Initialize(config)
 	case "http":
 		return http.Initialize(config)
+	case "homeassistant":
+		return homeassistant.Initialize(config)
 	default:
 		return nil, fmt.Errorf("gdo type %s not recognized", typeValue)
 	}

--- a/internal/gdo/homeassistant/homeassistant.go
+++ b/internal/gdo/homeassistant/homeassistant.go
@@ -54,22 +54,24 @@ func NewHomeAssistantGdo(config map[string]interface{}) (httpGdo.HttpGdo, error)
 	if httpSettings, ok := config["settings"].(map[string]interface{}); ok {
 		httpSettings["commands"] = []map[string]interface{}{
 			{
-				"name":                 "open",
-				"endpoint":             "/api/services/cover/open_cover",
-				"http_method":          "post",
-				"body":                 `{"entity_id": "` + hassGdo.Settings.EntityId + `"}`,
-				"required_start_state": "close3",
+				"name":                  "open",
+				"endpoint":              "/api/services/cover/open_cover",
+				"http_method":           "post",
+				"body":                  `{"entity_id": "` + hassGdo.Settings.EntityId + `"}`,
+				"required_start_state":  "closed",
+				"required_finish_state": "open",
 				"headers": []string{
 					"Authorization: Bearer " + hassGdo.Settings.Connection.ApiKey,
 					"Content-Type: application/json",
 				},
 			},
 			{
-				"name":                 "close",
-				"endpoint":             "/api/services/cover/close_cover",
-				"http_method":          "post",
-				"body":                 `{"entity_id": "` + hassGdo.Settings.EntityId + `"}`,
-				"required_start_state": "open",
+				"name":                  "close",
+				"endpoint":              "/api/services/cover/close_cover",
+				"http_method":           "post",
+				"body":                  `{"entity_id": "` + hassGdo.Settings.EntityId + `"}`,
+				"required_start_state":  "open",
+				"required_finish_state": "closed",
 				"headers": []string{
 					"Authorization: Bearer " + hassGdo.Settings.Connection.ApiKey,
 					"Content-Type: application/json",

--- a/internal/gdo/homeassistant/homeassistant.go
+++ b/internal/gdo/homeassistant/homeassistant.go
@@ -1,0 +1,115 @@
+package homeassistant
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	httpGdo "github.com/brchri/tesla-geogdo/internal/gdo/http"
+	"github.com/brchri/tesla-geogdo/internal/util"
+	logger "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+// stubbed struct to extract api key and entity id from the yaml to pass into what is expected by httpGdo
+type HomeAssistant struct {
+	Settings struct {
+		Connection struct {
+			ApiKey string `yaml:"api_key"`
+		} `yaml:"connection"`
+		EntityId string `yaml:"entity_id"`
+	} `yaml:"settings"`
+}
+
+func init() {
+	logger.SetFormatter(&util.CustomFormatter{})
+	logger.SetOutput(os.Stdout)
+	if val, ok := os.LookupEnv("DEBUG"); ok && strings.ToLower(val) == "true" {
+		logger.SetLevel(logger.DebugLevel)
+	}
+}
+
+// this is just a wrapper for the http package with some predefined settings for homeassistant
+func Initialize(config map[string]interface{}) (httpGdo.HttpGdo, error) {
+	h, err := NewHomeAssistantGdo(config)
+	if err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+func NewHomeAssistantGdo(config map[string]interface{}) (httpGdo.HttpGdo, error) {
+	var hassGdo *HomeAssistant
+	// marshall map[string]interface into yaml, then unmarshal to object based on yaml def in struct
+	yamlData, err := yaml.Marshal(config)
+	if err != nil {
+		logger.Fatal("Failed to marhsal garage doors yaml object")
+	}
+	err = yaml.Unmarshal(yamlData, &hassGdo)
+	if err != nil {
+		logger.Fatal("Failed to unmarhsal garage doors yaml object")
+	}
+
+	// add homeassistant-specific http settings to the config object
+	if httpSettings, ok := config["settings"].(map[string]interface{}); ok {
+		httpSettings["commands"] = []map[string]interface{}{
+			{
+				"name":                 "open",
+				"endpoint":             "/api/services/cover/open_cover",
+				"http_method":          "post",
+				"body":                 `{"entity_id": "` + hassGdo.Settings.EntityId + `"}`,
+				"required_start_state": "close3",
+				"headers": []string{
+					"Authorization: Bearer " + hassGdo.Settings.Connection.ApiKey,
+					"Content-Type: application/json",
+				},
+			},
+			{
+				"name":                 "close",
+				"endpoint":             "/api/services/cover/close_cover",
+				"http_method":          "post",
+				"body":                 `{"entity_id": "` + hassGdo.Settings.EntityId + `"}`,
+				"required_start_state": "open",
+				"headers": []string{
+					"Authorization: Bearer " + hassGdo.Settings.Connection.ApiKey,
+					"Content-Type: application/json",
+				},
+			},
+		}
+
+		httpSettings["status"] = map[string]interface{}{
+			"endpoint": "/api/states/" + hassGdo.Settings.EntityId,
+			"headers": []string{
+				"Authorization: Bearer " + hassGdo.Settings.Connection.ApiKey,
+				"Content-Type: application/json",
+			},
+		}
+	}
+
+	// create new httpGdo object with updated config
+	h, err := httpGdo.NewHttpGdo(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// set callback function for httpGdo object to parse returned garage status
+	h.SetExtractStatusCallbackFunction(ExtractStatusCallback)
+
+	return h, nil
+}
+
+// define a callback function for the httpGdo package to extract the garage status from the returned json
+// all that's needed is the json value for the `state` key
+func ExtractStatusCallback(status string) (string, error) {
+	type statusResponse struct {
+		State string `json:"state"`
+	}
+
+	var s statusResponse
+	err := json.Unmarshal([]byte(status), &s)
+	if err != nil {
+		logger.Debugf("Unable to parse")
+	}
+
+	return s.State, nil
+}

--- a/internal/gdo/homeassistant/homeassistant.go
+++ b/internal/gdo/homeassistant/homeassistant.go
@@ -17,7 +17,8 @@ type HomeAssistant struct {
 		Connection struct {
 			ApiKey string `yaml:"api_key"`
 		} `yaml:"connection"`
-		EntityId string `yaml:"entity_id"`
+		EntityId           string `yaml:"entity_id"`
+		EnableStatusChecks bool   `yaml:"enable_status_checks"`
 	} `yaml:"settings"`
 }
 
@@ -47,7 +48,7 @@ func NewHomeAssistantGdo(config map[string]interface{}) (httpGdo.HttpGdo, error)
 	}
 	err = yaml.Unmarshal(yamlData, &hassGdo)
 	if err != nil {
-		logger.Fatal("Failed to unmarhsal garage doors yaml object")
+		logger.Fatal("Failed to unmarshal garage doors yaml object")
 	}
 
 	// add homeassistant-specific http settings to the config object
@@ -79,12 +80,14 @@ func NewHomeAssistantGdo(config map[string]interface{}) (httpGdo.HttpGdo, error)
 			},
 		}
 
-		httpSettings["status"] = map[string]interface{}{
-			"endpoint": "/api/states/" + hassGdo.Settings.EntityId,
-			"headers": []string{
-				"Authorization: Bearer " + hassGdo.Settings.Connection.ApiKey,
-				"Content-Type: application/json",
-			},
+		if hassGdo.Settings.EnableStatusChecks {
+			httpSettings["status"] = map[string]interface{}{
+				"endpoint": "/api/states/" + hassGdo.Settings.EntityId,
+				"headers": []string{
+					"Authorization: Bearer " + hassGdo.Settings.Connection.ApiKey,
+					"Content-Type: application/json",
+				},
+			}
 		}
 	}
 

--- a/internal/gdo/homeassistant/homeassistant_test.go
+++ b/internal/gdo/homeassistant/homeassistant_test.go
@@ -17,7 +17,8 @@ var sampleYaml = map[string]interface{}{
 			"use_tls":         false,
 			"skip_tls_verify": false,
 		},
-		"entity_id": "cover.main_cover",
+		"entity_id":            "cover.main_cover",
+		"enable_status_checks": true,
 	},
 }
 

--- a/internal/gdo/homeassistant/homeassistant_test.go
+++ b/internal/gdo/homeassistant/homeassistant_test.go
@@ -1,0 +1,52 @@
+package homeassistant
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/brchri/tesla-geogdo/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+var sampleYaml = map[string]interface{}{
+	"settings": map[string]interface{}{
+		"connection": map[string]interface{}{
+			"host":            "localhost",
+			"port":            80,
+			"api_key":         "somelongtoken",
+			"use_tls":         false,
+			"skip_tls_verify": false,
+		},
+		"entity_id": "cover.main_cover",
+	},
+}
+
+// Since homeassistant is just a wrapper for httpGdo with some predefined configs,
+// just need to ensure NewRatgdo doesn't throw any errors when returning
+// an httpGdo object
+func Test_NewHomeAssistantGdo(t *testing.T) {
+	// test with sample config defined above
+	_, err := NewHomeAssistantGdo(sampleYaml)
+	assert.Equal(t, nil, err)
+
+	// test with sample config extracted from example config.yml file
+	util.LoadConfig(filepath.Join("..", "..", "..", "examples", "config.circular.homeassistant.yml"))
+	door := *util.Config.GarageDoors[0]
+	var openerConfig interface{}
+	for k, v := range door {
+		if k == "opener" {
+			openerConfig = v
+		}
+	}
+	if openerConfig == nil {
+		t.Error("unable to parse config from garage door")
+		return
+	}
+	config, ok := openerConfig.(map[string]interface{})
+	if !ok {
+		t.Error("unable to parse config from garage door")
+		return
+	}
+	_, err = NewHomeAssistantGdo(config)
+	assert.Equal(t, nil, err)
+}

--- a/internal/gdo/http/http.go
+++ b/internal/gdo/http/http.go
@@ -169,7 +169,7 @@ func (h *httpGdo) SetGarageDoor(action string) error {
 			return fmt.Errorf("unable to get door state, received err: %v", err)
 		}
 		if h.State != "" && h.State != command.RequiredStartState {
-			logger.Warnf("Action and state mismatch: garage state is not valid for executing requested action; current state %s; requrested action: %s", h.State, action)
+			logger.Warnf("Action and state mismatch: garage state is not valid for executing requested action; current state %s; requested action: %s", h.State, action)
 			return nil
 		}
 	}
@@ -222,6 +222,9 @@ func (h *httpGdo) SetGarageDoor(action string) error {
 	start := time.Now()
 	for time.Since(start) < time.Duration(command.Timeout)*time.Second {
 		h.State, err = h.getDoorStatus()
+		if err == nil && h.Settings.Status.ExtractStatusCallback != nil {
+			h.State, err = h.Settings.Status.ExtractStatusCallback(h.State)
+		}
 		if err != nil {
 			logger.Debugf("Unable to get door state, received err: %v", err)
 			logger.Debugf("Will keep trying until timeout expires")

--- a/internal/gdo/http/http.go
+++ b/internal/gdo/http/http.go
@@ -19,6 +19,10 @@ type (
 	HttpGdo interface {
 		SetGarageDoor(string) error
 		ProcessShutdown()
+		// sets a callback function that should be used to extract the status from an endpoint
+		// http responses can be complex json blobs, and a simple `open` or `closed` is generally
+		// expected for status; the callback function, if set, will be used to extract that
+		// simple status from more complex responses
 		SetExtractStatusCallbackFunction(ExtractStatusCallback)
 	}
 

--- a/internal/gdo/http/http.go
+++ b/internal/gdo/http/http.go
@@ -174,6 +174,11 @@ func (h *httpGdo) SetGarageDoor(action string) error {
 		}
 	}
 
+	if util.Config.Testing {
+		logger.Infof("TESTING flag set - Would attempt action %v", action)
+		return nil
+	}
+
 	// start building url and http client
 	url := "http"
 	if h.Settings.Connection.UseTls {

--- a/internal/gdo/http/http_test.go
+++ b/internal/gdo/http/http_test.go
@@ -22,6 +22,7 @@ type httpRequestData struct {
 	body     string
 	username string
 	password string
+	headers  []string
 }
 
 var sampleYaml = map[string]interface{}{
@@ -46,6 +47,9 @@ var sampleYaml = map[string]interface{}{
 				"required_start_state":  "closed",
 				"required_finish_state": "open",
 				"timeout":               5,
+				"headers": []string{
+					"mockAuth: Bearer somelongtoken",
+				},
 			}, {
 				"name":                  "close",
 				"endpoint":              "/close",
@@ -120,9 +124,10 @@ func mockServerHandler(w http.ResponseWriter, r *http.Request) {
 	body := string(bodyBytes)
 
 	httpRequest := httpRequestData{
-		method: r.Method,
-		path:   r.URL.Path,
-		body:   body,
+		method:  r.Method,
+		path:    r.URL.Path,
+		body:    body,
+		headers: r.Header.Values("mockAuth"),
 	}
 	httpRequest.username, httpRequest.password, _ = r.BasicAuth()
 
@@ -208,6 +213,7 @@ func Test_SetGarageDoor_Open_NoStatus(t *testing.T) {
 	assert.Equal(t, "/command", httpRequests[len(httpRequests)-1].path)
 	assert.Equal(t, "test-user", httpRequests[len(httpRequests)-1].username)
 	assert.Equal(t, "test-pass", httpRequests[len(httpRequests)-1].password)
+	assert.Equal(t, "Bearer somelongtoken", httpRequests[len(httpRequests)-1].headers[0])
 }
 
 // check SetGarageDoor with status checks


### PR DESCRIPTION
Adds support for controlling gdo's that are controlled by home assistant, by proxying the command through home assistant.