### PR TITLE
feat: enable any mqtt location trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,7 @@ garage_doors:
         prefix: home/garage/Main
     trackers:
       - id: 1
-        complex_topic:
-          topic: owntracks/owner
-          lat_json_key: lat
-          lng_json_key: lon
+        geofence_topic: teslamate/cars/1/geofence
 ```
 
 #### Polygon Geofence
@@ -200,8 +197,10 @@ garage_doors:
         prefix: home/garage/Main
     trackers:
       - id: 1
-        lat_topic: teslamate/cars/1/latitude
-        lng_topic: teslamate/cars/1/longitude
+        complex_topic:
+          topic: owntracks/owner
+          lat_json_key: lat
+          lng_json_key: lon
 ```
 
 Or, using a tool referenced above or any other of your choosing, you can generate and download a KML file containing your polygon geofences instead of manually defining the points in your config file. Be sure that the KML file is in a mounted volume and accessible within the container. Within your KML file, you *must* define a `name` element within each `Placemark` element for each geofence, with the value `open` or `close` accordingly. Please see the [polygon_map.kml](resources/polygon_map.kml) file for an example.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tesla-GeoGDO
-A lightweight app that will operate your smart Garage Door Openers (GDOs) based on the location of your Tesla vehicles, automatically closing when you leave, and opening when you return. Supports multiple vehicles, geofence types, and smart GDO devices.
+**NOTE: As of v2.0.0, this app works with any vehicle (using location tracking on your smartphone); it is no longer limited to tracking Teslas.**
+
+A lightweight app that will operate your smart Garage Door Openers (GDOs) based on the position of your location tracker (e.g. Tesla vehicle or phone location), automatically closing when you leave, and opening when you return. Supports multiple vehicles, location trackers (see [Prerequisites](#prerequisite)), geofence types, and smart GDO devices.
 
 <!-- TOC -->
 
@@ -35,16 +37,15 @@ A lightweight app that will operate your smart Garage Door Openers (GDOs) based 
   * [Meross](https://www.meross.com/en-gc/product) (if I get my hands on one or can use someone else's package to incorporate)
 
 ## Prerequisite
-This app uses the MQTT broker bundled with [TeslaMate](https://github.com/adriankumpf/teslamate). You must be running TeslaMate and have the MQTT broker exposed for consumption to use this app. TeslaMate has done a lot of work in scraping API data while minimizing vampire drain on vehicles from API requests, and TeslaMate has many other features that make it more than worthwhile to use in addition to this app.
+As of v2.0.0, this app supports any location tracker that can publish to an MQTT broker. For tesla vehicles, the easiest way to accomplish this is to use the [MQTT capabilities](https://docs.teslamate.org/docs/integrations/mqtt) of [TeslaMate](https://github.com/adriankumpf/teslamate). For other users, you can use an app like [OwnTracks](https://owntracks.org/) on your phone to publish your location to an MQTT broker for tracking.
 
-## How to use
+## How to Use
 ### Docker
 This app is provided as a docker image. You will need to create a `config.yml` file (please refer to the [examples directory](/examples) or the simplified [config.simple.example.yml](config.simple.example.yml)), edit it appropriately (***make sure to preserve the leading spaces, they are important***), and then mount it to the container at runtime. For example:
 
 ```bash
 # see docker compose example below for parameter explanations
 docker run \
-  --user 1000:1000 \
   -e TZ=America/New_York \
   -v /etc/tesla-geogdo:/app/config \
   brchri/tesla-geogdo:latest
@@ -58,7 +59,6 @@ services:
   tesla-geogdo:
     image: brchri/tesla-geogdo:latest
     container_name: tesla-geogdo
-    user: 1000:1000 # optional, sets user to run in container; must have read access to mounted config volume (+ write if using token caching)
     environment:
       - TZ=America/New_York # optional, sets timezone for container
     volumes:
@@ -71,8 +71,8 @@ The following Docker environment variables are supported but not required.
 | Variable Name | Type | Description |
 | ------------- | ---- | ----------- |
 | `CONFIG_FILE` | String (Filepath) | Path to config file within container |
-| `TESLAMATE_MQTT_USER` | String | User to authenticate to MQTT broker. Can be used instead of setting `teslamate.mqtt.user` in the `config.yml` file |
-| `TESLAMATE_MQTT_PASS` | String | Password to authenticate to MQTT broker. Can be used instead of setting `teslamate.mqtt.pass` in the `config.yml` file |
+| `TRACKER_MQTT_USER` | String | User to authenticate to MQTT broker. Can be used instead of setting `global.tracker_mqtt_settings.connection.user` in the `config.yml` file |
+| `TRACKER_MQTT_PASS` | String | Password to authenticate to MQTT broker. Can be used instead of setting `global.tracker_mqtt_settings.connection.pass` in the `config.yml` file |
 | `DEBUG` | Bool | Increases output verbosity |
 | `TESTING` | Bool | Will perform all functions *except* actually operating garage door, and will just output operation *would've* happened |
 | `TZ` | String | Sets timezone for container |
@@ -103,8 +103,10 @@ garage_doors:
           host: localhost
           port: 1883
         prefix: home/garage/Main
-    cars:
-      - teslamate_car_id: 1
+    trackers:
+      - id: 1
+        lat_topic: teslamate/cars/1/latitude
+        lng_topic: teslamate/cars/1/longitude
 ```
 This would produce two circular geofences (open and close) that look like this:
 
@@ -139,8 +141,12 @@ garage_doors:
           host: localhost
           port: 1883
         prefix: home/garage/Main
-    cars:
-      - teslamate_car_id: 1
+    trackers:
+      - id: 1
+        complex_topic:
+          topic: owntracks/owner
+          lat_json_key: lat
+          lng_json_key: lon
 ```
 
 #### Polygon Geofence
@@ -190,8 +196,10 @@ garage_doors:
           host: localhost
           port: 1883
         prefix: home/garage/Main
-    cars:
-      - teslamate_car_id: 1
+    trackers:
+      - id: 1
+        lat_topic: teslamate/cars/1/latitude
+        lng_topic: teslamate/cars/1/longitude
 ```
 
 Or, using a tool referenced above or any other of your choosing, you can generate and download a KML file containing your polygon geofences instead of manually defining the points in your config file. Be sure that the KML file is in a mounted volume and accessible within the container. Within your KML file, you *must* define a `name` element within each `Placemark` element for each geofence, with the value `open` or `close` accordingly. Please see the [polygon_map.kml](resources/polygon_map.kml) file for an example.
@@ -211,8 +219,10 @@ garage_doors:
           host: localhost
           port: 1883
         prefix: home/garage/Main
-    cars:
-      - teslamate_car_id: 1
+    trackers:
+      - id: 1
+        lat_topic: teslamate/cars/1/latitude
+        lng_topic: teslamate/cars/1/longitude
 ```
 
 Either of these configs would produce two polygonal geofences (open and close) that look like this:
@@ -227,3 +237,4 @@ There's a configurable `cooldown` parameter in the `config.yml` file's `global` 
 ## Credits
 * [TeslaMate](https://github.com/adriankumpf/teslamate)
 * [Ratgdo](https://paulwieland.github.io/ratgdo/)
+* [@DjAnu](https://github.com/DjAnu) for the idea to expand beyond Tesla vehicles and help with testing

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Tesla-GeoGDO
-**NOTE: As of v2.0.0, this app works with any vehicle (using location tracking on your smartphone); it is no longer limited to tracking Teslas.**
+**NOTE: As of v2.0.0, this app works with any location tracking that can publish to an MQTT broker (e.g. TeslaMate for Teslas, or the OwnTracks app for smartphones); it is no longer limited to tracking Teslas. See [Prerequisites](#prerequisite) for details.**
 
 A lightweight app that will operate your smart Garage Door Openers (GDOs) based on the position of your location tracker (e.g. Tesla vehicle or phone location), automatically closing when you leave, and opening when you return. Supports multiple vehicles, location trackers (see [Prerequisites](#prerequisite)), geofence types, and smart GDO devices.
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -271,6 +271,7 @@ func onMqttConnect(client mqtt.Client) {
 		possibleTopics := []string{
 			tracker.LatTopic,
 			tracker.LngTopic,
+			tracker.GeofenceTopic,
 			tracker.ComplexTopic.Topic,
 		}
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -236,23 +236,22 @@ func onMqttConnect(client mqtt.Client) {
 		logger.Infof("Subscribing to MQTT topics for car %d", car.ID)
 
 		// define which topics are relevant for each car based on config
-		topics := car.GarageDoor.Geofence.GetMqttTopics()
+		topics := car.GarageDoor.Geofence.GetMqttTopics(car.ID)
 
 		// subscribe to topics
 		for _, topic := range topics {
 			topicSubscribed := false
 			// retry topic subscription attempts with 1 sec delay between attempts
 			for retryAttempts := 5; retryAttempts > 0; retryAttempts-- {
-				fullTopic := fmt.Sprintf("%s", topic)
-				logger.Debugf("Subscribing to topic: %s", fullTopic)
+				logger.Debugf("Subscribing to topic: %s", topic)
 				if token := client.Subscribe(
-					fullTopic,
+					topic,
 					0,
 					func(client mqtt.Client, message mqtt.Message) {
 						messageChan <- message
 					}); token.Wait() && token.Error() == nil {
 					topicSubscribed = true
-					logger.Debugf("Topic subscribed successfully: %s", fullTopic)
+					logger.Debugf("Topic subscribed successfully: %s", topic)
 					break
 				} else {
 					logger.Infof("Failed to subscribe to topic %s for car %d, will make %d more attempts. Error: %v", topic, car.ID, retryAttempts, token.Error())

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -175,24 +175,24 @@ func main() {
 				var err error
 				switch message.Topic() {
 				case t.LatTopic:
-					logger.Debugf("Received lat for tracker %v: %v", t.ID, string(message.Payload()))
+					logger.Debugf("Received lat for tracker %v: %s", t.ID, string(message.Payload()))
 					point.Lat, err = strconv.ParseFloat(string(message.Payload()), 64)
 				case t.LngTopic:
-					logger.Debugf("Received long for tracker %v: %v", t.ID, string(message.Payload()))
+					logger.Debugf("Received long for tracker %v: %s", t.ID, string(message.Payload()))
 					point.Lng, err = strconv.ParseFloat(string(message.Payload()), 64)
 				case t.GeofenceTopic:
 					t.PrevGeofence = t.CurGeofence
 					t.CurGeofence = string(message.Payload())
-					logger.Infof("Received geo for tracker %v: %v", t.ID, t.CurGeofence)
+					logger.Infof("Received geo for tracker %v: %s", t.ID, t.CurGeofence)
 					go geo.CheckGeofence(t)
 					break topic
 				case t.ComplexTopic.Topic:
-					logger.Debugf("Received payload for complex toipc %s for tracker %v", message.Topic(), t.ID)
+					logger.Debugf("Received payload for complex toipc %s for tracker %v, payload:\n%s", message.Topic(), t.ID, string(message.Payload()))
 					point, err = processComplexTopicPayload(t, string(message.Payload()))
 				}
 
 				if err != nil {
-					logger.Errorf("could not parse message payload from topic for tracker %v, received error %e\nmessage payload: %s", t.ID, err, message.Payload())
+					logger.Errorf("could not parse message payload from topic for tracker %v, received error %v", t.ID, err)
 					break topic
 				}
 
@@ -315,12 +315,12 @@ func onMqttConnect(client mqtt.Client) {
 func checkEnvVars() {
 	logger.Debug("Checking environment variables:")
 	// override config with env vars if present
-	if value, exists := os.LookupEnv("TESLAMATE_MQTT_USER"); exists {
-		logger.Debug("  TESLAMATE_MQTT_USER defined, overriding config")
+	if value, exists := os.LookupEnv("TRACKER_MQTT_USER"); exists {
+		logger.Debug("  TRACKER_MQTT_USER defined, overriding config")
 		mqttSettings.User = value
 	}
-	if value, exists := os.LookupEnv("TESLAMATE_MQTT_PASS"); exists {
-		logger.Debug("  TESLAMATE_MQTT_PASS defined, overriding config")
+	if value, exists := os.LookupEnv("TRACKER_MQTT_PASS"); exists {
+		logger.Debug("  TRACKER_MQTT_PASS defined, overriding config")
 		mqttSettings.Pass = value
 	}
 	if value, exists := os.LookupEnv("TESTING"); exists {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -236,7 +236,11 @@ func onMqttConnect(client mqtt.Client) {
 		logger.Infof("Subscribing to MQTT topics for car %d", car.ID)
 
 		// define which topics are relevant for each car based on config
-		topics := car.GarageDoor.Geofence.GetMqttTopics()
+		// topics := car.GarageDoor.Geofence.GetMqttTopics()
+		topics := []string{
+			util.Config.Global.MqttSettings.LatTopic,
+			util.Config.Global.MqttSettings.LngTopic,
+		}
 
 		// subscribe to topics
 		for _, topic := range topics {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -236,18 +236,14 @@ func onMqttConnect(client mqtt.Client) {
 		logger.Infof("Subscribing to MQTT topics for car %d", car.ID)
 
 		// define which topics are relevant for each car based on config
-		// topics := car.GarageDoor.Geofence.GetMqttTopics()
-		topics := []string{
-			util.Config.Global.MqttSettings.LatTopic,
-			util.Config.Global.MqttSettings.LngTopic,
-		}
+		topics := car.GarageDoor.Geofence.GetMqttTopics()
 
 		// subscribe to topics
 		for _, topic := range topics {
 			topicSubscribed := false
 			// retry topic subscription attempts with 1 sec delay between attempts
 			for retryAttempts := 5; retryAttempts > 0; retryAttempts-- {
-				fullTopic := fmt.Sprintf("teslamate/cars/%d/%s", car.ID, topic)
+				fullTopic := fmt.Sprintf("%s", topic)
 				logger.Debugf("Subscribing to topic: %s", fullTopic)
 				if token := client.Subscribe(
 					fullTopic,

--- a/config.simple.example.yml
+++ b/config.simple.example.yml
@@ -2,7 +2,7 @@
 # To keep it clean, it won't explain any parameters; please refer to the examples in the `examples` folder for parameter explanations
 
 global:
-  teslamate_mqtt_settings:
+  tracker_mqtt_settings:
     connection: &mqtt_connection_settings
       host: localhost
       port: 1883

--- a/config.simple.example.yml
+++ b/config.simple.example.yml
@@ -21,5 +21,7 @@ garage_doors:
       mqtt_settings:
         connection: *mqtt_connection_settings
         prefix: home/garage/Main
-    cars:
-      - teslamate_car_id: 1
+    trackers:
+      - id: 1
+        lat_topic: teslamate/cars/1/latitude
+        lng_topic: teslamate/cars/1/longitude

--- a/examples/config.circular.homeassistant.yml
+++ b/examples/config.circular.homeassistant.yml
@@ -36,6 +36,10 @@ garage_doors:
           skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on home assistant
         entity_id: cover.main_door # id for the garage door entity in home assistant, can be found by adding '/config/entities' to the base url in home assistant
         enable_status_checks: true # set to true if gdo supports garage states (e.g. garage is closed)
-    cars: # list of cars that use this garage door
-      - teslamate_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
-      - teslamate_car_id: 2 # id used for the second vehicle in TeslaMate's MQTT broker
+    trackers:
+      - id: 1 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
+      - id: 2 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker

--- a/examples/config.circular.homeassistant.yml
+++ b/examples/config.circular.homeassistant.yml
@@ -4,9 +4,9 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  teslamate_mqtt_settings: # settings for teslamate's mqtt broker
+  mqtt_settings: # settings for tracker mqtt broker
     connection:
-      host: localhost # dns, container name, or IP of teslamate's mqtt host
+      host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
       client_id: tesla-geogdo # optional, arbitrary client name for MQTT connection; must not be the same as any other MQTT client name, will use random uuid if omitted
       user: mqtt_user # optional, only define if your mqtt broker requires authentication, can also be passed as env var MQTT_USER
@@ -25,7 +25,7 @@ garage_doors:
           lng: -123.79965087116439
         close_distance: .013 # distance in kilometers car must travel away from garage location to close garage door
         open_distance: .04 # distance in kilometers car must be in range of garage location while traveling closer to it to open garage door
-    opener:
+    opener:  # defines how to control the garage # defines how to control the garage
       type: homeassistant # type of garage door opener to use
       settings:
         connection: # connection settings for home assistant
@@ -36,7 +36,7 @@ garage_doors:
           skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on home assistant
         entity_id: cover.main_door # id for the garage door entity in home assistant, can be found by adding '/config/entities' to the base url in home assistant
         enable_status_checks: true # set to true if gdo supports garage states (e.g. garage is closed)
-    trackers:
+    trackers: # defines which trackers should be used to operate garage
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker

--- a/examples/config.circular.homeassistant.yml
+++ b/examples/config.circular.homeassistant.yml
@@ -4,7 +4,7 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  mqtt_settings: # settings for tracker mqtt broker
+  tracker_mqtt_settings: # settings for tracker mqtt broker
     connection:
       host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
@@ -36,10 +36,12 @@ garage_doors:
           skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on home assistant
         entity_id: cover.main_door # id for the garage door entity in home assistant, can be found by adding '/config/entities' to the base url in home assistant
         enable_status_checks: true # set to true if gdo supports garage states (e.g. garage is closed)
-    trackers: # defines which trackers should be used to operate garage
+    trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
       - id: 2 # required, some identifier, can be number or string
-        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
-        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker
+        complex_topic: # if lat and lng are published to a single topic via json payload, use this instead of lat_topic and lng_topic
+          topic: some/complex/topic
+          lat_json_key: lat # json key for latitude; only top-level json keys are supported, cannot be nested within other json keys
+          lng_json_key: lng # json key for longitude; only top-level json keys are supported, cannot be nested within other json keys

--- a/examples/config.circular.homebridge.yml
+++ b/examples/config.circular.homebridge.yml
@@ -4,7 +4,7 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  mqtt_settings: # settings for tracker mqtt broker
+  tracker_mqtt_settings: # settings for tracker mqtt broker
     connection:
       host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
@@ -44,10 +44,12 @@ garage_doors:
             values: # defines expected values for status and command characteristics
               open: 0 # defines value for characteristic to open door
               close: 1 # defines value for characteristic to close door
-    trackers: # defines which trackers should be used to operate garage
+    trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
       - id: 2 # required, some identifier, can be number or string
-        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
-        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker
+        complex_topic: # if lat and lng are published to a single topic via json payload, use this instead of lat_topic and lng_topic
+          topic: some/complex/topic
+          lat_json_key: lat # json key for latitude; only top-level json keys are supported, cannot be nested within other json keys
+          lng_json_key: lng # json key for longitude; only top-level json keys are supported, cannot be nested within other json keys

--- a/examples/config.circular.homebridge.yml
+++ b/examples/config.circular.homebridge.yml
@@ -44,6 +44,10 @@ garage_doors:
             values: # defines expected values for status and command characteristics
               open: 0 # defines value for characteristic to open door
               close: 1 # defines value for characteristic to close door
-    cars: # list of cars that use this garage door
-      - teslamate_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
-      - teslamate_car_id: 2 # id used for the second vehicle in TeslaMate's MQTT broker
+    trackers:
+      - id: 1 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
+      - id: 2 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker

--- a/examples/config.circular.homebridge.yml
+++ b/examples/config.circular.homebridge.yml
@@ -4,9 +4,9 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  teslamate_mqtt_settings: # settings for teslamate's mqtt broker
+  mqtt_settings: # settings for tracker mqtt broker
     connection:
-      host: localhost # dns, container name, or IP of teslamate's mqtt host
+      host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
       client_id: tesla-geogdo # optional, arbitrary client name for MQTT connection; must not be the same as any other MQTT client name, will use random uuid if omitted
       user: mqtt_user # optional, only define if your mqtt broker requires authentication, can also be passed as env var MQTT_USER
@@ -25,7 +25,7 @@ garage_doors:
           lng: -123.79965087116439
         close_distance: .013 # distance in kilometers car must travel away from garage location to close garage door
         open_distance: .04 # distance in kilometers car must be in range of garage location while traveling closer to it to open garage door
-    opener:
+    opener:  # defines how to control the garage
       type: homebridge # type of garage door opener to use
       settings:
         connection: # connection settings for homebridge
@@ -44,7 +44,7 @@ garage_doors:
             values: # defines expected values for status and command characteristics
               open: 0 # defines value for characteristic to open door
               close: 1 # defines value for characteristic to close door
-    trackers:
+    trackers: # defines which trackers should be used to operate garage
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker

--- a/examples/config.circular.ratgdo.yml
+++ b/examples/config.circular.ratgdo.yml
@@ -38,6 +38,10 @@ garage_doors:
           use_tls: false # optional, instructs app to connect to mqtt broker using tls (defaults to false)
           skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on the mqtt broker
         topic_prefix: home/garage/Main # required
-    cars: # list of cars that use this garage door
-      - teslamate_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
-      - teslamate_car_id: 2 # id used for the second vehicle in TeslaMate's MQTT broker
+    trackers:
+      - id: 1 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
+      - id: 2 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker

--- a/examples/config.circular.ratgdo.yml
+++ b/examples/config.circular.ratgdo.yml
@@ -4,9 +4,9 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  teslamate_mqtt_settings: # settings for teslamate's mqtt broker
+  mqtt_settings: # settings for tracker mqtt broker
     connection:
-      host: localhost # dns, container name, or IP of teslamate's mqtt host
+      host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
       client_id: tesla-geogdo # optional, arbitrary client name for MQTT connection; must not be the same as any other MQTT client name, will use random uuid if omitted
       user: mqtt_user # optional, only define if your mqtt broker requires authentication, can also be passed as env var MQTT_USER
@@ -25,7 +25,7 @@ garage_doors:
           lng: -123.79965087116439
         close_distance: .013 # distance in kilometers car must travel away from garage location to close garage door
         open_distance: .04 # distance in kilometers car must be in range of garage location while traveling closer to it to open garage door
-    opener:
+    opener:  # defines how to control the garage
       type: ratgdo # type of garage door opener to use
       mqtt_settings: # mqtt broker settings for ratgdo
         connection: # connection settings for the broker
@@ -38,7 +38,7 @@ garage_doors:
           use_tls: false # optional, instructs app to connect to mqtt broker using tls (defaults to false)
           skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on the mqtt broker
         topic_prefix: home/garage/Main # required
-    trackers:
+    trackers: # defines which trackers should be used to operate garage
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker

--- a/examples/config.circular.ratgdo.yml
+++ b/examples/config.circular.ratgdo.yml
@@ -4,7 +4,7 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  mqtt_settings: # settings for tracker mqtt broker
+  tracker_mqtt_settings: # settings for tracker mqtt broker
     connection:
       host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
@@ -38,10 +38,12 @@ garage_doors:
           use_tls: false # optional, instructs app to connect to mqtt broker using tls (defaults to false)
           skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on the mqtt broker
         topic_prefix: home/garage/Main # required
-    trackers: # defines which trackers should be used to operate garage
+    trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
       - id: 2 # required, some identifier, can be number or string
-        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
-        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker
+        complex_topic: # if lat and lng are published to a single topic via json payload, use this instead of lat_topic and lng_topic
+          topic: some/complex/topic
+          lat_json_key: lat # json key for latitude; only top-level json keys are supported, cannot be nested within other json keys
+          lng_json_key: lng # json key for longitude; only top-level json keys are supported, cannot be nested within other json keys

--- a/examples/config.multiple.yml
+++ b/examples/config.multiple.yml
@@ -7,7 +7,7 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  mqtt_settings:
+  tracker_mqtt_settings:
     connection: &mqtt_connection_settings
       host: localhost
       port: 1883
@@ -33,7 +33,7 @@ garage_doors:
           client_id: tesla-geogdo-ratgdo1
           # WARNING!! client_id's MUST BE UNIQUE for any mqtt client that shares a broker !!
         topic_prefix: home/garage/Main
-    trackers: # defines which trackers should be used to operate garage
+    trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
@@ -72,7 +72,7 @@ garage_doors:
             topic_suffix: command/door
             required_start_state: open
             required_finish_state: closed
-    trackers: # defines which trackers should be used to operate garage
+    trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 3 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/3/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/3/longitude # topic to retrieve longitude for tracker
@@ -103,7 +103,9 @@ garage_doors:
             body: 
             required_start_state: open
             required_finish_state: closed
-    trackers: # defines which trackers should be used to operate garage
+    trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 4 # required, some identifier, can be number or string
-        lat_topic: teslamate/cars/4/latitude # topic to retrieve latitude for tracker
-        lng_topic: teslamate/cars/4/longitude # topic to retrieve longitude for tracker
+        complex_topic: # if lat and lng are published to a single topic via json payload, use this instead of lat_topic and lng_topic
+          topic: some/complex/topic
+          lat_json_key: lat # json key for latitude; only top-level json keys are supported, cannot be nested within other json keys
+          lng_json_key: lng # json key for longitude; only top-level json keys are supported, cannot be nested within other json keys

--- a/examples/config.multiple.yml
+++ b/examples/config.multiple.yml
@@ -33,9 +33,13 @@ garage_doors:
           client_id: tesla-geogdo-ratgdo1
           # WARNING!! client_id's MUST BE UNIQUE for any mqtt client that shares a broker !!
         topic_prefix: home/garage/Main
-    cars:
-      - teslamate_car_id: 1
-      - teslamate_car_id: 2
+    trackers:
+      - id: 1 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
+      - id: 2 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker
 
   - # 3rd car garage example
     geofence:
@@ -68,8 +72,10 @@ garage_doors:
             topic_suffix: command/door
             required_start_state: open
             required_finish_state: closed
-    cars:
-      - teslamate_car_id: 3
+    trackers:
+      - id: 3 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/3/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/3/longitude # topic to retrieve longitude for tracker
 
   - # 4th car detached garage example
     geofence:
@@ -97,5 +103,7 @@ garage_doors:
             body: 
             required_start_state: open
             required_finish_state: closed
-    cars:
-      - teslamate_car_id: 4
+    trackers:
+      - id: 4 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/4/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/4/longitude # topic to retrieve longitude for tracker

--- a/examples/config.multiple.yml
+++ b/examples/config.multiple.yml
@@ -7,7 +7,7 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  teslamate_mqtt_settings:
+  mqtt_settings:
     connection: &mqtt_connection_settings
       host: localhost
       port: 1883
@@ -24,7 +24,7 @@ garage_doors:
           lng: -123.79965087116439
         close_distance: .013
         open_distance: .04
-    opener:
+    opener:  # defines how to control the garage
       type: ratgdo
       mqtt_settings:
         connection:
@@ -33,7 +33,7 @@ garage_doors:
           client_id: tesla-geogdo-ratgdo1
           # WARNING!! client_id's MUST BE UNIQUE for any mqtt client that shares a broker !!
         topic_prefix: home/garage/Main
-    trackers:
+    trackers: # defines which trackers should be used to operate garage
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
@@ -51,7 +51,7 @@ garage_doors:
         open_trigger:
           from: not_home
           to: home
-    opener:
+    opener:  # defines how to control the garage
       type: mqtt
       settings:
         connection:
@@ -72,7 +72,7 @@ garage_doors:
             topic_suffix: command/door
             required_start_state: open
             required_finish_state: closed
-    trackers:
+    trackers: # defines which trackers should be used to operate garage
       - id: 3 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/3/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/3/longitude # topic to retrieve longitude for tracker
@@ -82,7 +82,7 @@ garage_doors:
       type: polygon
       settings:
         kml_file: ../../resources/polygon_map.kml
-    opener:
+    opener:  # defines how to control the garage
       type: http
       settings:
         connection:
@@ -103,7 +103,7 @@ garage_doors:
             body: 
             required_start_state: open
             required_finish_state: closed
-    trackers:
+    trackers: # defines which trackers should be used to operate garage
       - id: 4 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/4/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/4/longitude # topic to retrieve longitude for tracker

--- a/examples/config.polygon.http.yml
+++ b/examples/config.polygon.http.yml
@@ -93,3 +93,7 @@ garage_doors:
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
+        complex_topic: # if topic combines lat and long into single topic with json payload, define this instead of lat_topic and lng_topic
+          topic: some/complex/topic # topic where complex payload is published
+          lat_json_key: "lat" # json key for latitude
+          lng_json_key: "lon" # json key for longitude

--- a/examples/config.polygon.http.yml
+++ b/examples/config.polygon.http.yml
@@ -89,5 +89,7 @@ garage_doors:
             headers: # optional, list of headers, each must be surrounded by single quotes
               - 'Authorization: Bearer long_api_key' # example header
               - 'Content-Type: application/json' # example header
-    cars:
-      - teslamate_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
+    trackers:
+      - id: 1 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker

--- a/examples/config.polygon.http.yml
+++ b/examples/config.polygon.http.yml
@@ -4,7 +4,7 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  mqtt_settings: # settings for tracker mqtt broker
+  tracker_mqtt_settings: # settings for tracker mqtt broker
     connection:
       host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
@@ -64,7 +64,7 @@ garage_doors:
         status:
             endpoint: /status # optional, GET endpoint to retrieve current door status; expects simple return values like `open` or `closed`
             headers: # optional, list of headers, each must be surrounded by single quotes
-              - 'Authorization: Bearer long_api_key' # example header
+              - 'Authorization: Bearer lng_api_key' # example header
               - 'Content-Type: application/json' # example header
         commands:
           # /command endpoint with a body to indicate the command type
@@ -76,7 +76,7 @@ garage_doors:
             required_finish_state: open # optional; if status endpoint is available, require this stop state to confirm successful command execution
             timeout: 25 # optional, seconds to wait for garage door operation to complete if watching the status (default 30)
             headers: # optional, list of headers, each must be surrounded by single quotes
-              - 'Authorization: Bearer long_api_key' # example header
+              - 'Authorization: Bearer lng_api_key' # example header
               - 'Content-Type: application/json' # example header
           # /close endpoint with no body required, as the endpoint /close defines the type
           - name: close
@@ -87,13 +87,13 @@ garage_doors:
             required_finish_state: closed
             timeout: 25
             headers: # optional, list of headers, each must be surrounded by single quotes
-              - 'Authorization: Bearer long_api_key' # example header
+              - 'Authorization: Bearer lng_api_key' # example header
               - 'Content-Type: application/json' # example header
-    trackers: # defines which trackers should be used to operate garage
+    trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
-        complex_topic: # if topic combines lat and long into single topic with json payload, define this instead of lat_topic and lng_topic
-          topic: some/complex/topic # topic where complex payload is published
-          lat_json_key: "lat" # json key for latitude
-          lng_json_key: "lon" # json key for longitude
+        complex_topic: # if lat and lng are published to a single topic via json payload, use this instead of lat_topic and lng_topic
+          topic: some/complex/topic
+          lat_json_key: lat # json key for latitude; only top-level json keys are supported, cannot be nested within other json keys
+          lng_json_key: lng # json key for longitude; only top-level json keys are supported, cannot be nested within other json keys

--- a/examples/config.polygon.http.yml
+++ b/examples/config.polygon.http.yml
@@ -4,9 +4,9 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  teslamate_mqtt_settings: # settings for teslamate's mqtt broker
+  mqtt_settings: # settings for tracker mqtt broker
     connection:
-      host: localhost # dns, container name, or IP of teslamate's mqtt host
+      host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
       client_id: tesla-geogdo # optional, arbitrary client name for MQTT connection; must not be the same as any other MQTT client name, will use random uuid if omitted
       user: mqtt_user # optional, only define if your mqtt broker requires authentication, can also be passed as env var MQTT_USER
@@ -51,7 +51,7 @@ garage_doors:
             lng: -123.79950958978756
           - lat: 46.192958467582514
             lng: -123.7998033090239
-    opener:
+    opener:  # defines how to control the garage
       type: http # type of garage door opener to use
       settings:
         connection:
@@ -89,7 +89,7 @@ garage_doors:
             headers: # optional, list of headers, each must be surrounded by single quotes
               - 'Authorization: Bearer long_api_key' # example header
               - 'Content-Type: application/json' # example header
-    trackers:
+    trackers: # defines which trackers should be used to operate garage
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker

--- a/examples/config.teslamate.mqtt.yml
+++ b/examples/config.teslamate.mqtt.yml
@@ -54,5 +54,10 @@ garage_doors:
             topic_suffix: command/door
             required_start_state: open
             required_finish_state: closed
-    cars:
-      - teslamate_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
+    trackers:
+      - id: 1 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
+      - id: 2 # required, some identifier, can be number or string
+        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
+        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker

--- a/examples/config.teslamate.mqtt.yml
+++ b/examples/config.teslamate.mqtt.yml
@@ -4,9 +4,9 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  teslamate_mqtt_settings: # settings for teslamate's mqtt broker
+  mqtt_settings: # settings for tracker mqtt broker
     connection:
-      host: localhost # dns, container name, or IP of teslamate's mqtt host
+      host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
       client_id: tesla-geogdo # optional, arbitrary client name for MQTT connection; must not be the same as any other MQTT client name, will use random uuid if omitted
       user: mqtt_user # optional, only define if your mqtt broker requires authentication, can also be passed as env var MQTT_USER
@@ -26,7 +26,7 @@ garage_doors:
         open_trigger: # define which geofence changes trigger an open action (e.g. moving from `not_home` geofence to `home`)
           from: not_home
           to: home
-    opener:
+    opener:  # defines how to control the garage
       type: mqtt # type of garage door opener to use
       settings:
         connection:
@@ -54,7 +54,7 @@ garage_doors:
             topic_suffix: command/door
             required_start_state: open
             required_finish_state: closed
-    trackers:
+    trackers: # defines which trackers should be used to operate garage
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker

--- a/examples/config.teslamate.mqtt.yml
+++ b/examples/config.teslamate.mqtt.yml
@@ -4,7 +4,7 @@
 # Spacing is very important in this file, particularly the leading spacing (indentations). Failure to properly indent may cause config parsing to fail silently
 
 global:
-  mqtt_settings: # settings for tracker mqtt broker
+  tracker_mqtt_settings: # settings for tracker mqtt broker
     connection:
       host: localhost # dns, container name, or IP of tracker mqtt host
       port: 1883
@@ -54,10 +54,12 @@ garage_doors:
             topic_suffix: command/door
             required_start_state: open
             required_finish_state: closed
-    trackers: # defines which trackers should be used to operate garage
+    trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
         lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
       - id: 2 # required, some identifier, can be number or string
-        lat_topic: teslamate/cars/2/latitude # topic to retrieve latitude for tracker
-        lng_topic: teslamate/cars/2/longitude # topic to retrieve longitude for tracker
+        complex_topic: # if lat and lng are published to a single topic via json payload, use this instead of lat_topic and lng_topic
+          topic: some/complex/topic
+          lat_json_key: lat # json key for latitude; only top-level json keys are supported, cannot be nested within other json keys
+          lng_json_key: lng # json key for longitude; only top-level json keys are supported, cannot be nested within other json keys

--- a/examples/config.teslamate.mqtt.yml
+++ b/examples/config.teslamate.mqtt.yml
@@ -56,10 +56,4 @@ garage_doors:
             required_finish_state: closed
     trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
-        lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker
-        lng_topic: teslamate/cars/1/longitude # topic to retrieve longitude for tracker
-      - id: 2 # required, some identifier, can be number or string
-        complex_topic: # if lat and lng are published to a single topic via json payload, use this instead of lat_topic and lng_topic
-          topic: some/complex/topic
-          lat_json_key: lat # json key for latitude; only top-level json keys are supported, cannot be nested within other json keys
-          lng_json_key: lng # json key for longitude; only top-level json keys are supported, cannot be nested within other json keys
+        geofence_topic: teslamate/cars/1/geofence

--- a/internal/gdo/homebridge/homebridge.go
+++ b/internal/gdo/homebridge/homebridge.go
@@ -120,7 +120,7 @@ func (h *homebridgeGdo) SetGarageDoor(action string) error {
 	logger.Debugf("Setting garage door target state: %s", action)
 	err := h.login()
 	if err != nil {
-		return fmt.Errorf("unable to login, received error %e", err)
+		return fmt.Errorf("unable to login, received error %v", err)
 	}
 
 	var desiredTargetState string
@@ -137,7 +137,7 @@ func (h *homebridgeGdo) SetGarageDoor(action string) error {
 	if h.Settings.Accessory.Characteristics.Status != "" {
 		state, err := h.getDoorStatus()
 		if err != nil {
-			return fmt.Errorf("unable to get door status, received error %e", err)
+			return fmt.Errorf("unable to get door status, received error %v", err)
 		}
 		if state != desiredStartState {
 			logger.Warnf("Action and state mismatch: garage state is not valid for executing requested action; current state %s; requested action: %s", state, action)
@@ -165,7 +165,7 @@ func (h *homebridgeGdo) SetGarageDoor(action string) error {
 	}
 	_, err = h.ExecuteApiCall(endpoint, "PUT", string(body), headers)
 	if err != nil {
-		return fmt.Errorf("received error when executing api call to homebridge server: %e", err)
+		return fmt.Errorf("received error when executing api call to homebridge server: %v", err)
 	}
 	if h.Settings.Accessory.Characteristics.Status == "" {
 		logger.Debug("request sent successfully, but no status characteristic defined, unable to determine if operation successful")
@@ -237,7 +237,7 @@ func (h *homebridgeGdo) login() error {
 	endpoint := "/api/auth/login"
 	body, err := json.Marshal(lb)
 	if err != nil {
-		return fmt.Errorf("unable to marshal json for username and password, received error: %e", err)
+		return fmt.Errorf("unable to marshal json for username and password, received error: %v", err)
 	}
 
 	headers := map[string]string{
@@ -246,7 +246,7 @@ func (h *homebridgeGdo) login() error {
 
 	rBody, err := h.ExecuteApiCall(endpoint, "POST", string(body), headers)
 	if err != nil {
-		return fmt.Errorf("received error when executing api call: %e", err)
+		return fmt.Errorf("received error when executing api call: %v", err)
 	}
 
 	type respBody struct {

--- a/internal/geo/circular.go
+++ b/internal/geo/circular.go
@@ -17,13 +17,12 @@ type (
 	}
 )
 
-var circularMqttTopics = []string{
-	util.Config.Global.MqttSettings.LatTopic,
-	util.Config.Global.MqttSettings.LngTopic,
-}
-
-func (c *CircularGeofence) GetMqttTopics() []string {
-	return circularMqttTopics
+func (c *CircularGeofence) GetMqttTopics(carId int) []string {
+	// doesn't care about carId, just needs to match interface signature
+	return []string{
+		util.Config.Global.MqttSettings.LatTopic,
+		util.Config.Global.MqttSettings.LngTopic,
+	}
 }
 
 func distance(point1 Point, point2 Point) float64 {

--- a/internal/geo/circular.go
+++ b/internal/geo/circular.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	util "github.com/brchri/tesla-geogdo/internal/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,7 +17,10 @@ type (
 	}
 )
 
-var circularMqttTopics = []string{"latitude", "longitude"}
+var circularMqttTopics = []string{
+	util.Config.Global.MqttSettings.LatTopic,
+	util.Config.Global.MqttSettings.LngTopic,
+}
 
 func (c *CircularGeofence) GetMqttTopics() []string {
 	return circularMqttTopics

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -49,7 +49,7 @@ type (
 		// and what action should be taken if those are different (indicating a crossing of geofences)
 		getEventChangeAction(*Car) string
 		// get teslamate mqtt topics relevant to the implemented geofence type
-		GetMqttTopics() []string
+		GetMqttTopics(carId int) []string
 		// parse the settings: of a geofence into the specific geofence type struct
 		parseSettings(map[string]interface{}) error
 	}

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -30,6 +30,12 @@ type (
 		InsidePolyCloseGeo bool        // indicates if tracker is currently inside the polygon_close_geofence
 		LatTopic           string      `yaml:"lat_topic"`
 		LngTopic           string      `yaml:"lng_topic"`
+		GeofenceTopic      string      `yaml:"geofence_topic"` // topic for publishing a geofence name where a tracker resides, e.g. teslamate geofence indicating 'home' or 'not_home'
+		ComplexTopic       struct {
+			Topic      string `yaml:"topic"`
+			LatJsonKey string `yaml:"lat_json_key"`
+			LngJsonKey string `yaml:"lng_json_key"`
+		} `yaml:"complex_topic"`
 	}
 
 	// defines a garage door with one unique geofence type: circular, teslamate, or polygon

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -18,16 +18,18 @@ type (
 		Lng float64 `yaml:"lng"`
 	}
 
-	Car struct {
-		ID                 int         `yaml:"teslamate_car_id"` // mqtt identifier for vehicle
-		GarageDoor         *GarageDoor // bidirectional pointer to GarageDoor containing car
+	Tracker struct {
+		ID                 interface{} `yaml:"id"` // mqtt identifier for vehicle
+		GarageDoor         *GarageDoor // bidirectional pointer to GarageDoor containing tracker
 		CurrentLocation    Point       // current vehicle location
 		LocationUpdate     chan Point  // channel to receive location updates
 		CurDistance        float64     // current distance from garagedoor location
-		PrevGeofence       string      // geofence previously ascribed to car
-		CurGeofence        string      // updated geofence ascribed to car when published to mqtt
-		InsidePolyOpenGeo  bool        // indicates if car is currently inside the polygon_open_geofence
-		InsidePolyCloseGeo bool        // indicates if car is currently inside the polygon_close_geofence
+		PrevGeofence       string      // geofence previously ascribed to tracker
+		CurGeofence        string      // updated geofence ascribed to tracker when published to mqtt
+		InsidePolyOpenGeo  bool        // indicates if tracker is currently inside the polygon_open_geofence
+		InsidePolyCloseGeo bool        // indicates if tracker is currently inside the polygon_close_geofence
+		LatTopic           string      `yaml:"lat_topic"`
+		LngTopic           string      `yaml:"lng_topic"`
 	}
 
 	// defines a garage door with one unique geofence type: circular, teslamate, or polygon
@@ -37,19 +39,17 @@ type (
 		Geofence       GeofenceInterface      `yaml:"-"` // geofence; don't parse this from the geofence yaml
 		Opener         gdo.GDO                `yaml:"-"` // garage door opener; don't parse this from the garage door yaml
 		GeofenceConfig map[string]interface{} `yaml:"geofence"`
-		OpenerConfig   map[string]interface{} `yaml:"opener"` // holds gdo config that is parsed on gdo.Initialize
-		Cars           []*Car                 `yaml:"cars"`   // cars housed within this garage
+		OpenerConfig   map[string]interface{} `yaml:"opener"`   // holds gdo config that is parsed on gdo.Initialize
+		Trackers       []*Tracker             `yaml:"trackers"` // trackers housed within this garage
 		OpLock         bool                   // controls if garagedoor has been operated recently to prevent flapping
 	}
 
 	// interface to represent geofence object
 	GeofenceInterface interface {
 		// check for an event trigger if a geofence is crossed and return appropriate action
-		// determines if a car is currently within a geofence, if it was previously,
+		// determines if a tracker is currently within a geofence, if it was previously,
 		// and what action should be taken if those are different (indicating a crossing of geofences)
-		getEventChangeAction(*Car) string
-		// get teslamate mqtt topics relevant to the implemented geofence type
-		GetMqttTopics(carId int) []string
+		getEventChangeAction(*Tracker) string
 		// parse the settings: of a geofence into the specific geofence type struct
 		parseSettings(map[string]interface{}) error
 	}
@@ -79,33 +79,33 @@ func (p Point) IsPointDefined() bool {
 }
 
 // check if outside close geo or inside open geo and set garage door state accordingly
-func CheckGeofence(car *Car) {
+func CheckGeofence(tracker *Tracker) {
 
 	// get action based on either geo cross events or distance threshold cross events
-	action := car.GarageDoor.Geofence.getEventChangeAction(car)
+	action := tracker.GarageDoor.Geofence.getEventChangeAction(tracker)
 
 	if action == "" {
 		return // nothing to do
 	}
-	if car.GarageDoor.OpLock {
+	if tracker.GarageDoor.OpLock {
 		logger.Debugf("Garage operation is locked (due to either cooldown or current activity), will not execute action '%s'", action)
 		return
 	}
 
-	car.GarageDoor.OpLock = true // set lock so no other threads try to operate the garage before the cooldown period is complete
+	tracker.GarageDoor.OpLock = true // set lock so no other threads try to operate the garage before the cooldown period is complete
 	// send operation to garage door and wait for timeout to release oplock
 	// run as goroutine to prevent blocking update channels from mqtt broker in main
 	go func() {
-		switch car.GarageDoor.Geofence.(type) {
+		switch tracker.GarageDoor.Geofence.(type) {
 		case *TeslamateGeofence:
-			logger.Infof("Attempting to %s garage door for car %d", action, car.ID)
+			logger.Infof("Attempting to %s garage door for tracker %v", action, tracker.ID)
 		default:
-			logger.Infof("Attempting to %s garage door for car %d at lat %f, long %f", action, car.ID, car.CurrentLocation.Lat, car.CurrentLocation.Lng)
+			logger.Infof("Attempting to %s garage door for tracker %v at lat %f, long %f", action, tracker.ID, tracker.CurrentLocation.Lat, tracker.CurrentLocation.Lng)
 		}
 
 		// create retry loop to set the garage door state
 		for i := 1; i > 0; i-- { // temporarily setting to 1 to disable retry logic while myq auth endpoint stabilizes to avoid rate limiting
-			err := car.GarageDoor.Opener.SetGarageDoor(action)
+			err := tracker.GarageDoor.Opener.SetGarageDoor(action)
 			if err == nil {
 				// no error received, so breaking retry loop)
 				break
@@ -121,12 +121,12 @@ func CheckGeofence(car *Car) {
 		if util.Config.Global.OpCooldown > 0 {
 			time.Sleep(time.Duration(util.Config.Global.OpCooldown) * time.Minute) // keep opLock true for OpCooldown minutes to prevent flapping in case of overlapping geofences
 		} else if os.Getenv("GDO_SKIP_FLAP_DELAY") != "true" {
-			// because lat and long are processed individually, it's possible that a car may flap briefly on the geofence crossing which can spam action calls to the gdo
+			// because lat and long are processed individually, it's possible that a tracker may flap briefly on the geofence crossing which can spam action calls to the gdo
 			// add a small sleep to prevent this
-			logger.Debugf("Garage for car %d retaining oplock for 5s to mitigate flapping when crossing geofence...", car.ID)
+			logger.Debugf("Garage for tracker %v retaining oplock for 5s to mitigate flapping when crossing geofence...", tracker.ID)
 			time.Sleep(5000 * time.Millisecond)
 		}
-		car.GarageDoor.OpLock = false // release garage door's operation lock
+		tracker.GarageDoor.OpLock = false // release garage door's operation lock
 	}()
 }
 
@@ -146,8 +146,8 @@ func ParseGarageDoorConfig() {
 		logger.Fatal("Unable to find garage doors in config! Please ensure proper spacing in the config file")
 	}
 	for i, g := range GarageDoors {
-		if len(g.Cars) == 0 {
-			logger.Fatalf("No cars found for garage door #%d! Please ensure proper spacing in the config file", i)
+		if len(g.Trackers) == 0 {
+			logger.Fatalf("No trackers found for garage door #%d! Please ensure proper spacing in the config file", i)
 		}
 
 		g.Geofence, err = newGeofence(g.GeofenceConfig)
@@ -161,7 +161,7 @@ func ParseGarageDoorConfig() {
 		}
 
 		// initialize location update channel
-		for _, c := range g.Cars {
+		for _, c := range g.Trackers {
 			c.LocationUpdate = make(chan Point)
 		}
 	}

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -14,16 +14,16 @@ import (
 )
 
 var (
-	distanceCar        *Car
+	distanceTracker    *Tracker
 	distanceGarageDoor *GarageDoor
 	distanceGeofence   *CircularGeofence
 
 	teslamateGarageDoor *GarageDoor
-	teslamateCar        *Car
+	teslamateTracker    *Tracker
 	teslamateGeofence   *TeslamateGeofence
 
 	polygonGarageDoor *GarageDoor
-	polygonCar        *Car
+	polygonTracker    *Tracker
 	polygonGeofence   *PolygonGeofence
 )
 
@@ -34,21 +34,21 @@ func init() {
 
 	// used for testing events based on distance
 	distanceGarageDoor = GarageDoors[0]
-	distanceCar = distanceGarageDoor.Cars[0]
-	distanceCar.GarageDoor = distanceGarageDoor
-	distanceGeofence, _ = distanceCar.GarageDoor.Geofence.(*CircularGeofence) // type cast geofence interface
+	distanceTracker = distanceGarageDoor.Trackers[0]
+	distanceTracker.GarageDoor = distanceGarageDoor
+	distanceGeofence, _ = distanceTracker.GarageDoor.Geofence.(*CircularGeofence) // type cast geofence interface
 
 	// used for testing events based on teslamate geofence changes
 	teslamateGarageDoor = GarageDoors[1]
-	teslamateCar = teslamateGarageDoor.Cars[0]
-	teslamateCar.GarageDoor = teslamateGarageDoor
-	teslamateGeofence, _ = teslamateCar.GarageDoor.Geofence.(*TeslamateGeofence) // type cast geofence interface
+	teslamateTracker = teslamateGarageDoor.Trackers[0]
+	teslamateTracker.GarageDoor = teslamateGarageDoor
+	teslamateGeofence, _ = teslamateTracker.GarageDoor.Geofence.(*TeslamateGeofence) // type cast geofence interface
 
 	// used for testing events based on teslamate geofence changes
 	polygonGarageDoor = GarageDoors[2]
-	polygonCar = polygonGarageDoor.Cars[0]
-	polygonCar.GarageDoor = polygonGarageDoor
-	polygonGeofence, _ = polygonCar.GarageDoor.Geofence.(*PolygonGeofence) // type cast geofence interface
+	polygonTracker = polygonGarageDoor.Trackers[0]
+	polygonTracker.GarageDoor = polygonGarageDoor
+	polygonGeofence, _ = polygonTracker.GarageDoor.Geofence.(*PolygonGeofence) // type cast geofence interface
 
 	util.Config.Global.OpCooldown = 0
 
@@ -56,29 +56,29 @@ func init() {
 }
 
 func Test_getEventChangeAction_Circular(t *testing.T) {
-	distanceCar.CurDistance = 0
-	distanceCar.CurrentLocation.Lat = distanceGeofence.Center.Lat + 10
-	distanceCar.CurrentLocation.Lng = distanceGeofence.Center.Lng
+	distanceTracker.CurDistance = 0
+	distanceTracker.CurrentLocation.Lat = distanceGeofence.Center.Lat + 10
+	distanceTracker.CurrentLocation.Lng = distanceGeofence.Center.Lng
 
-	assert.Equal(t, ActionClose, distanceCar.GarageDoor.Geofence.getEventChangeAction(distanceCar))
-	assert.Greater(t, distanceCar.CurDistance, distanceGeofence.CloseDistance)
+	assert.Equal(t, ActionClose, distanceTracker.GarageDoor.Geofence.getEventChangeAction(distanceTracker))
+	assert.Greater(t, distanceTracker.CurDistance, distanceGeofence.CloseDistance)
 
-	distanceCar.CurrentLocation.Lat = distanceGeofence.Center.Lat
+	distanceTracker.CurrentLocation.Lat = distanceGeofence.Center.Lat
 
-	assert.Equal(t, ActionOpen, distanceCar.GarageDoor.Geofence.getEventChangeAction(distanceCar))
-	assert.Less(t, distanceCar.CurDistance, distanceGeofence.OpenDistance)
+	assert.Equal(t, ActionOpen, distanceTracker.GarageDoor.Geofence.getEventChangeAction(distanceTracker))
+	assert.Less(t, distanceTracker.CurDistance, distanceGeofence.OpenDistance)
 }
 
 func Test_getEventChangeAction_Teslamate(t *testing.T) {
-	teslamateCar.PrevGeofence = "home"
-	teslamateCar.CurGeofence = "not_home"
+	teslamateTracker.PrevGeofence = "home"
+	teslamateTracker.CurGeofence = "not_home"
 
-	assert.Equal(t, ActionClose, teslamateCar.GarageDoor.Geofence.getEventChangeAction(teslamateCar))
+	assert.Equal(t, ActionClose, teslamateTracker.GarageDoor.Geofence.getEventChangeAction(teslamateTracker))
 
-	teslamateCar.PrevGeofence = "not_home"
-	teslamateCar.CurGeofence = "home"
+	teslamateTracker.PrevGeofence = "not_home"
+	teslamateTracker.CurGeofence = "home"
 
-	assert.Equal(t, ActionOpen, teslamateCar.GarageDoor.Geofence.getEventChangeAction(teslamateCar))
+	assert.Equal(t, ActionOpen, teslamateTracker.GarageDoor.Geofence.getEventChangeAction(teslamateTracker))
 }
 
 func Test_isInsidePolygonGeo(t *testing.T) {
@@ -98,83 +98,83 @@ func Test_isInsidePolygonGeo(t *testing.T) {
 }
 
 func Test_getEventAction_Polygon(t *testing.T) {
-	polygonCar.InsidePolyCloseGeo = true
-	polygonCar.InsidePolyOpenGeo = true
-	polygonCar.CurrentLocation.Lat = 46.19292902096646
-	polygonCar.CurrentLocation.Lng = -123.79984989897177
+	polygonTracker.InsidePolyCloseGeo = true
+	polygonTracker.InsidePolyOpenGeo = true
+	polygonTracker.CurrentLocation.Lat = 46.19292902096646
+	polygonTracker.CurrentLocation.Lng = -123.79984989897177
 
-	assert.Equal(t, ActionClose, polygonCar.GarageDoor.Geofence.getEventChangeAction(polygonCar))
-	assert.Equal(t, false, polygonCar.InsidePolyCloseGeo)
-	assert.Equal(t, true, polygonCar.InsidePolyOpenGeo)
+	assert.Equal(t, ActionClose, polygonTracker.GarageDoor.Geofence.getEventChangeAction(polygonTracker))
+	assert.Equal(t, false, polygonTracker.InsidePolyCloseGeo)
+	assert.Equal(t, true, polygonTracker.InsidePolyOpenGeo)
 
-	polygonCar.InsidePolyOpenGeo = false
-	polygonCar.CurrentLocation.Lat = 46.19243683948096
-	polygonCar.CurrentLocation.Lng = -123.80103692981524
+	polygonTracker.InsidePolyOpenGeo = false
+	polygonTracker.CurrentLocation.Lat = 46.19243683948096
+	polygonTracker.CurrentLocation.Lng = -123.80103692981524
 
-	assert.Equal(t, ActionOpen, polygonCar.GarageDoor.Geofence.getEventChangeAction(polygonCar))
+	assert.Equal(t, ActionOpen, polygonTracker.GarageDoor.Geofence.getEventChangeAction(polygonTracker))
 }
 
 func Test_CheckCircularGeofence_Leaving(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	distanceCar.GarageDoor.Opener = mockGdo
+	distanceTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	mockGdo.EXPECT().SetGarageDoor(ActionClose).Return(nil)
 
-	distanceCar.CurDistance = 0
-	distanceCar.CurrentLocation.Lat = distanceGeofence.Center.Lat + 10
-	distanceCar.CurrentLocation.Lng = distanceGeofence.Center.Lng
+	distanceTracker.CurDistance = 0
+	distanceTracker.CurrentLocation.Lat = distanceGeofence.Center.Lat + 10
+	distanceTracker.CurrentLocation.Lng = distanceGeofence.Center.Lng
 
-	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
+	assert.Equal(t, checkGeofenceWrapper(distanceTracker), true)
 }
 
 // if close is not defined, should not trigger any action
 func Test_CheckCircularGeofence_Leaving_NoClose(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	distanceCar.GarageDoor.Opener = mockGdo
+	distanceTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	prevCloseDistance := distanceGeofence.CloseDistance
 	distanceGeofence.CloseDistance = 0
 
-	distanceCar.CurDistance = 0
-	distanceCar.CurrentLocation.Lat = distanceGeofence.Center.Lat + 10
-	distanceCar.CurrentLocation.Lng = distanceGeofence.Center.Lng
+	distanceTracker.CurDistance = 0
+	distanceTracker.CurrentLocation.Lat = distanceGeofence.Center.Lat + 10
+	distanceTracker.CurrentLocation.Lng = distanceGeofence.Center.Lng
 
-	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
+	assert.Equal(t, checkGeofenceWrapper(distanceTracker), true)
 	distanceGeofence.CloseDistance = prevCloseDistance // restore settings
 }
 
 func Test_CheckCircularGeofence_Arriving(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	distanceCar.GarageDoor.Opener = mockGdo
+	distanceTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	mockGdo.EXPECT().SetGarageDoor(ActionOpen).Return(nil)
 
-	distanceCar.CurDistance = 100
-	distanceCar.CurrentLocation.Lat = distanceGeofence.Center.Lat
-	distanceCar.CurrentLocation.Lng = distanceGeofence.Center.Lng
+	distanceTracker.CurDistance = 100
+	distanceTracker.CurrentLocation.Lat = distanceGeofence.Center.Lat
+	distanceTracker.CurrentLocation.Lng = distanceGeofence.Center.Lng
 
-	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
+	assert.Equal(t, checkGeofenceWrapper(distanceTracker), true)
 }
 
 func Test_CheckCircularGeofence_LeaveThenArrive(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	distanceCar.GarageDoor.Opener = mockGdo
+	distanceTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	// TEST 1 - Leaving home, garage close
 	mockGdo.EXPECT().SetGarageDoor(ActionClose).Return(nil)
 
-	distanceCar.CurDistance = 0
-	distanceCar.CurrentLocation.Lat = distanceGeofence.Center.Lat + 10
-	distanceCar.CurrentLocation.Lng = distanceGeofence.Center.Lng
+	distanceTracker.CurDistance = 0
+	distanceTracker.CurrentLocation.Lat = distanceGeofence.Center.Lat + 10
+	distanceTracker.CurrentLocation.Lng = distanceGeofence.Center.Lng
 
-	CheckGeofence(distanceCar)
+	CheckGeofence(distanceTracker)
 	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
 	for {
-		if !distanceCar.GarageDoor.OpLock {
+		if !distanceTracker.GarageDoor.OpLock {
 			break
 		}
 	}
@@ -184,112 +184,112 @@ func Test_CheckCircularGeofence_LeaveThenArrive(t *testing.T) {
 	// TEST 2 - Arriving home, garage open
 	mockGdo.EXPECT().SetGarageDoor(ActionOpen).Return(nil)
 
-	distanceCar.CurrentLocation.Lat = distanceGeofence.Center.Lat
-	distanceCar.CurrentLocation.Lng = distanceGeofence.Center.Lng
+	distanceTracker.CurrentLocation.Lat = distanceGeofence.Center.Lat
+	distanceTracker.CurrentLocation.Lng = distanceGeofence.Center.Lng
 
-	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
+	assert.Equal(t, checkGeofenceWrapper(distanceTracker), true)
 }
 
 func Test_CheckTeslamateGeofence_Leaving(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	teslamateCar.GarageDoor.Opener = mockGdo
+	teslamateTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	// TEST 1 - Leaving home, garage close
 	mockGdo.EXPECT().SetGarageDoor(ActionClose).Return(nil)
 
-	teslamateCar.PrevGeofence = "home"
-	teslamateCar.CurGeofence = "not_home"
+	teslamateTracker.PrevGeofence = "home"
+	teslamateTracker.CurGeofence = "not_home"
 
-	assert.Equal(t, checkGeofenceWrapper(teslamateCar), true)
+	assert.Equal(t, checkGeofenceWrapper(teslamateTracker), true)
 }
 
 func Test_CheckTeslamateGeofence_Leaving_NoClose(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	teslamateCar.GarageDoor.Opener = mockGdo
+	teslamateTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	prevGeofenceClose := teslamateGeofence.Close
 	teslamateGeofence.Close = TeslamateGeofenceTrigger{}
 
-	teslamateCar.PrevGeofence = "home"
-	teslamateCar.CurGeofence = "not_home"
+	teslamateTracker.PrevGeofence = "home"
+	teslamateTracker.CurGeofence = "not_home"
 
-	assert.Equal(t, checkGeofenceWrapper(teslamateCar), true)
+	assert.Equal(t, checkGeofenceWrapper(teslamateTracker), true)
 	teslamateGeofence.Close = prevGeofenceClose // restore settings
 }
 
 func Test_CheckTeslamateGeofence_Arriving(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	teslamateCar.GarageDoor.Opener = mockGdo
+	teslamateTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	// TEST 1 - Arriving home, garage open
 	mockGdo.EXPECT().SetGarageDoor(ActionOpen).Return(nil)
 
-	teslamateCar.PrevGeofence = "not_home"
-	teslamateCar.CurGeofence = "home"
+	teslamateTracker.PrevGeofence = "not_home"
+	teslamateTracker.CurGeofence = "home"
 
-	assert.Equal(t, checkGeofenceWrapper(teslamateCar), true)
+	assert.Equal(t, checkGeofenceWrapper(teslamateTracker), true)
 }
 
 func Test_CheckPolyGeofence_Leaving(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	polygonCar.GarageDoor.Opener = mockGdo
+	polygonTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	// TEST 1 - Leaving home, garage close
 	mockGdo.EXPECT().SetGarageDoor(ActionClose).Return(nil)
 
-	polygonCar.InsidePolyCloseGeo = true
-	polygonCar.InsidePolyOpenGeo = true
-	polygonCar.CurrentLocation.Lat = 46.19292902096646
-	polygonCar.CurrentLocation.Lng = -123.79984989897177
+	polygonTracker.InsidePolyCloseGeo = true
+	polygonTracker.InsidePolyOpenGeo = true
+	polygonTracker.CurrentLocation.Lat = 46.19292902096646
+	polygonTracker.CurrentLocation.Lng = -123.79984989897177
 
-	assert.Equal(t, checkGeofenceWrapper(polygonCar), true)
+	assert.Equal(t, checkGeofenceWrapper(polygonTracker), true)
 }
 
 func Test_CheckPolyGeofence_Arriving(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	polygonCar.GarageDoor.Opener = mockGdo
+	polygonTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	// TEST 1 - Arriving home, garage open
 	mockGdo.EXPECT().SetGarageDoor(ActionOpen).Return(nil)
 
-	polygonCar.InsidePolyCloseGeo = false
-	polygonCar.InsidePolyOpenGeo = false
-	polygonCar.CurrentLocation.Lat = 46.19243683948096
-	polygonCar.CurrentLocation.Lng = -123.80103692981524
+	polygonTracker.InsidePolyCloseGeo = false
+	polygonTracker.InsidePolyOpenGeo = false
+	polygonTracker.CurrentLocation.Lat = 46.19243683948096
+	polygonTracker.CurrentLocation.Lng = -123.80103692981524
 
-	assert.Equal(t, checkGeofenceWrapper(polygonCar), true)
+	assert.Equal(t, checkGeofenceWrapper(polygonTracker), true)
 }
 
 // if close is not defined, should not trigger any action
 func Test_CheckPolyGeofence_Leaving_NoClose(t *testing.T) {
 	mockGdo := &mocks.GDO{}
-	polygonCar.GarageDoor.Opener = mockGdo
+	polygonTracker.GarageDoor.Opener = mockGdo
 	defer mockGdo.AssertExpectations(t)
 
 	prevCloseGeofence := polygonGeofence.Close
 	polygonGeofence.Close = []Point{}
 
-	polygonCar.InsidePolyCloseGeo = true
-	polygonCar.InsidePolyOpenGeo = true
-	polygonCar.CurrentLocation.Lat = 46.19243683948096
-	polygonCar.CurrentLocation.Lng = -123.80103692981524
+	polygonTracker.InsidePolyCloseGeo = true
+	polygonTracker.InsidePolyOpenGeo = true
+	polygonTracker.CurrentLocation.Lat = 46.19243683948096
+	polygonTracker.CurrentLocation.Lng = -123.80103692981524
 
-	assert.Equal(t, checkGeofenceWrapper(polygonCar), true)
+	assert.Equal(t, checkGeofenceWrapper(polygonTracker), true)
 	polygonGeofence.Close = prevCloseGeofence // restore settings
 }
 
 // runs CheckGeofence and waits for the internal goroutine to complete, signified by the release of oplock,
 // with 100 ms timeout
-func checkGeofenceWrapper(car *Car) bool {
-	CheckGeofence(car)
+func checkGeofenceWrapper(tracker *Tracker) bool {
+	CheckGeofence(tracker)
 	// wait for oplock to be released with a 100 ms timeout
 	for i := 0; i < 10; i++ {
-		if !car.GarageDoor.OpLock {
+		if !tracker.GarageDoor.OpLock {
 			return true
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/geo/polygon.go
+++ b/internal/geo/polygon.go
@@ -87,14 +87,14 @@ func loadKMLFile(p *PolygonGeofence) error {
 	fileContent, err := os.ReadFile(p.KMLFile)
 	lowerKML := strings.ToLower(string(fileContent)) // convert xml to lower to make xml tag parsing case insensitive
 	if err != nil {
-		logger.Infof("Could not read file %s, received error: %e", p.KMLFile, err)
+		logger.Infof("Could not read file %s, received error: %v", p.KMLFile, err)
 		return err
 	}
 
 	var kml KML
 	err = xml.Unmarshal([]byte(lowerKML), &kml)
 	if err != nil {
-		logger.Infof("Could not load kml from file %s, received error: %e", p.KMLFile, err)
+		logger.Infof("Could not load kml from file %s, received error: %v", p.KMLFile, err)
 		return err
 	}
 
@@ -117,12 +117,12 @@ func loadKMLFile(p *PolygonGeofence) error {
 			coords := strings.Split(c, ",")
 			lat, err := strconv.ParseFloat(coords[1], 64)
 			if err != nil {
-				logger.Infof("Could not parse lng/lat coordinates from line %s, received error: %e", c, err)
+				logger.Infof("Could not parse lng/lat coordinates from line %s, received error: %v", c, err)
 				return err
 			}
 			lng, err := strconv.ParseFloat(coords[0], 64)
 			if err != nil {
-				logger.Infof("Could not parse lng/lat coordinates from line %s, received error: %e", c, err)
+				logger.Infof("Could not parse lng/lat coordinates from line %s, received error: %v", c, err)
 				return err
 			}
 

--- a/internal/geo/polygon.go
+++ b/internal/geo/polygon.go
@@ -45,32 +45,24 @@ func init() {
 	}
 }
 
-func (p *PolygonGeofence) GetMqttTopics(carId int) []string {
-	// doesn't care about carId, just needs to match interface signature
-	return []string{
-		util.Config.Global.MqttSettings.LatTopic,
-		util.Config.Global.MqttSettings.LngTopic,
-	}
-}
-
 // get action based on whether we had a polygon geofence change event
 // uses ray-casting algorithm, assumes a simple geofence (no holes or border cross points)
-func (p *PolygonGeofence) getEventChangeAction(car *Car) (action string) {
-	if !car.CurrentLocation.IsPointDefined() {
+func (p *PolygonGeofence) getEventChangeAction(tracker *Tracker) (action string) {
+	if !tracker.CurrentLocation.IsPointDefined() {
 		return // need valid lat and long to check geofence
 	}
 
-	isInsideCloseGeo := isInsidePolygonGeo(car.CurrentLocation, p.Close)
-	isInsideOpenGeo := isInsidePolygonGeo(car.CurrentLocation, p.Open)
+	isInsideCloseGeo := isInsidePolygonGeo(tracker.CurrentLocation, p.Close)
+	isInsideOpenGeo := isInsidePolygonGeo(tracker.CurrentLocation, p.Open)
 
-	if len(p.Close) > 0 && car.InsidePolyCloseGeo && !isInsideCloseGeo { // if we were inside the close geofence and now we're not, then close
+	if len(p.Close) > 0 && tracker.InsidePolyCloseGeo && !isInsideCloseGeo { // if we were inside the close geofence and now we're not, then close
 		action = ActionClose
-	} else if len(p.Open) > 0 && !car.InsidePolyOpenGeo && isInsideOpenGeo { // if we were not inside the open geo and now we are, then open
+	} else if len(p.Open) > 0 && !tracker.InsidePolyOpenGeo && isInsideOpenGeo { // if we were not inside the open geo and now we are, then open
 		action = ActionOpen
 	}
 
-	car.InsidePolyCloseGeo = isInsideCloseGeo
-	car.InsidePolyOpenGeo = isInsideOpenGeo
+	tracker.InsidePolyCloseGeo = isInsideCloseGeo
+	tracker.InsidePolyOpenGeo = isInsideOpenGeo
 
 	return
 }

--- a/internal/geo/polygon.go
+++ b/internal/geo/polygon.go
@@ -37,11 +37,6 @@ type (
 	}
 )
 
-var polygonMqttTopics = []string{
-	util.Config.Global.MqttSettings.LatTopic,
-	util.Config.Global.MqttSettings.LngTopic,
-}
-
 func init() {
 	logger.SetFormatter(&util.CustomFormatter{})
 	logger.SetOutput(os.Stdout)
@@ -50,8 +45,12 @@ func init() {
 	}
 }
 
-func (p *PolygonGeofence) GetMqttTopics() []string {
-	return polygonMqttTopics
+func (p *PolygonGeofence) GetMqttTopics(carId int) []string {
+	// doesn't care about carId, just needs to match interface signature
+	return []string{
+		util.Config.Global.MqttSettings.LatTopic,
+		util.Config.Global.MqttSettings.LngTopic,
+	}
 }
 
 // get action based on whether we had a polygon geofence change event

--- a/internal/geo/polygon.go
+++ b/internal/geo/polygon.go
@@ -37,7 +37,10 @@ type (
 	}
 )
 
-var polygonMqttTopics = []string{"latitude", "longitude"}
+var polygonMqttTopics = []string{
+	util.Config.Global.MqttSettings.LatTopic,
+	util.Config.Global.MqttSettings.LngTopic,
+}
 
 func init() {
 	logger.SetFormatter(&util.CustomFormatter{})

--- a/internal/geo/teslamate_geofence.go
+++ b/internal/geo/teslamate_geofence.go
@@ -20,19 +20,15 @@ type (
 	}
 )
 
-func (t *TeslamateGeofence) GetMqttTopics(carId int) []string {
-	return []string{fmt.Sprintf("teslamate/cars/%d/geofence", carId)}
-}
-
 // gets action based on if there was a relevant geofence event change
-func (t *TeslamateGeofence) getEventChangeAction(car *Car) (action string) {
+func (t *TeslamateGeofence) getEventChangeAction(tracker *Tracker) (action string) {
 	if t.Close.IsTriggerDefined() &&
-		car.PrevGeofence == t.Close.From &&
-		car.CurGeofence == t.Close.To {
+		tracker.PrevGeofence == t.Close.From &&
+		tracker.CurGeofence == t.Close.To {
 		action = ActionClose
 	} else if t.Open.IsTriggerDefined() &&
-		car.PrevGeofence == t.Open.From &&
-		car.CurGeofence == t.Open.To {
+		tracker.PrevGeofence == t.Open.From &&
+		tracker.CurGeofence == t.Open.To {
 		action = ActionOpen
 	}
 	return

--- a/internal/geo/teslamate_geofence.go
+++ b/internal/geo/teslamate_geofence.go
@@ -20,10 +20,8 @@ type (
 	}
 )
 
-var teslamateMqttTopics = []string{"geofence"}
-
-func (t *TeslamateGeofence) GetMqttTopics() []string {
-	return teslamateMqttTopics
+func (t *TeslamateGeofence) GetMqttTopics(carId int) []string {
+	return []string{fmt.Sprintf("teslamate/cars/%d/geofence", carId)}
 }
 
 // gets action based on if there was a relevant geofence event change

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -14,8 +14,6 @@ type (
 		Global struct {
 			MqttSettings struct {
 				Connection MqttConnectSettings `yaml:"connection"`
-				LatTopic   string              `yaml:"lat_topic"`
-				LngTopic   string              `yaml:"lng_topic"`
 			} `yaml:"mqtt_settings"`
 			OpCooldown int `yaml:"cooldown"`
 		} `yaml:"global"`

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -14,7 +14,7 @@ type (
 		Global struct {
 			MqttSettings struct {
 				Connection MqttConnectSettings `yaml:"connection"`
-			} `yaml:"mqtt_settings"`
+			} `yaml:"tracker_mqtt_settings"`
 			OpCooldown int `yaml:"cooldown"`
 		} `yaml:"global"`
 		GarageDoors []*map[string]interface{} `yaml:"garage_doors"` // this will be parsed properly later by the geo package

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -14,7 +14,9 @@ type (
 		Global struct {
 			MqttSettings struct {
 				Connection MqttConnectSettings `yaml:"connection"`
-			} `yaml:"teslamate_mqtt_settings"`
+				LatTopic   string              `yaml:"lat_topic"`
+				LngTopic   string              `yaml:"lng_topic"`
+			} `yaml:"mqtt_settings"`
 			OpCooldown int `yaml:"cooldown"`
 		} `yaml:"global"`
 		GarageDoors []*map[string]interface{} `yaml:"garage_doors"` // this will be parsed properly later by the geo package


### PR DESCRIPTION
Add support for any tracker that can publish to an MQTT broker, such as TeslaMate or OwnTracks. This will enable usage for any vehicle when using a tracking app on a phone to publish location data to an MQTT broker.

This includes breaking changes to the config file, and users should always check the examples directory for how to structure config files.