### PR TITLE
fix: add delay when entering or leaving geofence to prevent flap

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -267,17 +267,13 @@ func onMqttConnect(client mqtt.Client) {
 		logger.Infof("Subscribing to MQTT topics for tracker %v", tracker.ID)
 
 		// define which topics are relevant for each tracker based on config
-
-		possibleTopics := []string{
+		topics := []string{}
+		for _, t := range []string{
 			tracker.LatTopic,
 			tracker.LngTopic,
 			tracker.GeofenceTopic,
 			tracker.ComplexTopic.Topic,
-		}
-
-		// need to remove any undefined topics
-		topics := []string{}
-		for _, t := range possibleTopics {
+		} {
 			if t != "" {
 				topics = append(topics, t)
 			}


### PR DESCRIPTION
It's possible while leaving or entering a geofence to incorrectly trigger an event, for example, when leaving an open geofence, it may appear to the app that the tracker left the geofence and then immediately returned inside, triggering an open event. This is due to how lat and lng are processed independently.

To prevent this, a timer is being added to each tracker for each geofence type defined. This will prevent triggering an open event if a tracker has just left and then immediately re-entered an open geofence, and vice-versa for a close geofence.

As a note, it's not currently possible to wait to process lat and lng as a pair, as both lat and lng are not always published together, for example if a tracker is traveling directly east or west, only the lng gets updated, lat does not, as the lat is not changing. As such, there's no way to determine if a lat or lng update will have a corresponding pair, so they must be processed independently, even though it results in slightly incorrect positioning when the pair hasn't yet been processed. For the most part, this is harmless, but it did cause this issue as it appeared that the tracker was teleporting out of a geofence and then back in. Putting a flap timer in should resolve this while still allowing the processing of lat and lng independently.