### PR TITLE
feat: add pause http api command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ A lightweight app that will operate your smart Garage Door Openers (GDOs) based 
 
 - [Tesla-GeoGDO](#tesla-geogdo)
   - [Supported Smart Garage Door Openers](#supported-smart-garage-door-openers)
+    - [Current](#current)
+    - [Deprecated:](#deprecated)
+    - [Potentially Upcoming](#potentially-upcoming)
   - [Prerequisite](#prerequisite)
-  - [How to use](#how-to-use)
+  - [How to Use](#how-to-use)
     - [Docker](#docker)
     - [Supported Environment Variables](#supported-environment-variables)
+    - [API](#api)
   - [Notes](#notes)
     - [Geofence Types](#geofence-types)
-      - [Circular Geofence](#circular-geofence)
-      - [TeslaMate Defined Geofence](#teslamate-defined-geofence)
-      - [Polygon Geofence](#polygon-geofence)
     - [Operation Cooldown](#operation-cooldown)
   - [Credits](#credits)
 
@@ -50,6 +51,7 @@ This app is provided as a docker image. You will need to create a `config.yml` f
 docker run \
   -e TZ=America/New_York \
   -v /etc/tesla-geogdo:/app/config \
+  -p 8555:8555 \
   brchri/tesla-geogdo:latest
 ```
 
@@ -63,6 +65,8 @@ services:
     container_name: tesla-geogdo
     environment:
       - TZ=America/New_York # optional, sets timezone for container
+    ports:
+      - 8555:8555 # optional, only needed to use api
     volumes:
       - /etc/tesla-geogdo:/app/config # required, mounts folder containing config file(s) into container
     restart: unless-stopped
@@ -78,6 +82,20 @@ The following Docker environment variables are supported but not required.
 | `DEBUG` | Bool | Increases output verbosity |
 | `TESTING` | Bool | Will perform all functions *except* actually operating garage door, and will just output operation *would've* happened |
 | `TZ` | String | Sets timezone for container |
+
+### API
+There is a very simple API available that will allow you limited control of Tesla-GeoGDO remotely. To use it, you must expose a port mapping to port 8555 in the container (see the docker run and docker compose examples above). There are currently two endpoints available:
+
+* `GET /pause`
+  * Pauses garage operations. Takes an optional `duration` parameter to define how long garage operations should be paused, in seconds
+  * Can override previous pause command (e.g. increase the remaining time of a pause command currently in effect)
+  * Examples:
+    * `curl http://geogdo-ip:8555/pause?duration=10` (pauses garage operations for 10 seconds)
+    * `curl http://geogdo-ip:8555/pause` (pauses garage operations indefinitely)
+* `GET /resume`
+  * Resumes garage operations if they are currently paused; otherwise has no effect
+  * Example:
+    * `curl http://geogdo-ip:8555/resume`
 
 ## Notes
 ### Geofence Types

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -409,7 +409,7 @@ func pauseOperations(duration int) {
 				default:
 				}
 			}
-			logger.Debug("Pause duration reached; unpausing operation")
+			logger.Info("Pause timeout reached; unpausing operations")
 			util.Config.MasterOpLock = 0
 		}()
 	}
@@ -421,7 +421,7 @@ func pauseOperations(duration int) {
 // runnin goroutine with the updated value; else it will set the lock back to 0,
 // which is the disabled value (thereby resuming garage operations)
 func resumeOperations() {
-	logger.Info("Received request to resume operations")
+	logger.Info("Received request to resume operations, resuming...")
 	if util.Config.MasterOpLock > 0 {
 		// send signal to pause timeout loop it's no longer needed
 		// send as goroutine as we only read channel every 1 second, so this ensures fast api response while waiting for channel to be read by loop

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -95,8 +95,8 @@ func CheckGeofence(tracker *Tracker) {
 	if action == "" {
 		return // nothing to do
 	}
-	if util.Config.MasterOpLock {
-		logger.Warnf("Garage operations are currently paused due to user request, will not execute action '%s'", action)
+	if util.Config.MasterOpLock != 0 {
+		logger.Warnf("Garage operations are currently paused due to user request, will not execute action '%s'. Use /resume api endpoint to resume garage operations", action)
 		return
 	}
 	if tracker.GarageDoor.OpLock {

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -87,6 +87,10 @@ func CheckGeofence(car *Car) {
 	if action == "" {
 		return // nothing to do
 	}
+	if util.Config.MasterOpLock {
+		logger.Warnf("Garage operations are currently paused due to user request, will not execute action '%s'", action)
+		return
+	}
 	if car.GarageDoor.OpLock {
 		logger.Debugf("Garage operation is locked (due to either cooldown or current activity), will not execute action '%s'", action)
 		return

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -17,8 +17,9 @@ type (
 			} `yaml:"teslamate_mqtt_settings"`
 			OpCooldown int `yaml:"cooldown"`
 		} `yaml:"global"`
-		GarageDoors []*map[string]interface{} `yaml:"garage_doors"` // this will be parsed properly later by the geo package
-		Testing     bool
+		GarageDoors  []*map[string]interface{} `yaml:"garage_doors"` // this will be parsed properly later by the geo package
+		Testing      bool
+		MasterOpLock bool
 	}
 
 	MqttConnectSettings struct {

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -19,7 +19,7 @@ type (
 		} `yaml:"global"`
 		GarageDoors  []*map[string]interface{} `yaml:"garage_doors"` // this will be parsed properly later by the geo package
 		Testing      bool
-		MasterOpLock bool
+		MasterOpLock int // user-initiated lock (pause), values: 0 = disabled, <0 = indefinite pause, >0 = num seconds left on finite timeout
 	}
 
 	MqttConnectSettings struct {


### PR DESCRIPTION
Adds a simple http listener with endpoints `/pause` and `/resume` GET endpoints, listening on port `8555`. Calling these endpoints will pause and resume garage door operations respectively. `/pause` can be called with the optional query string argument `duration`, where the duration is the number of seconds the operations should be paused for. Omitting this or setting the value to `0` will pause indefinitely, until the app is restarted or the `/resume` endpoint is called. `/resume` can also be called to resume a timed pause operation early.

Only garage door operations are paused with this endpoint. Tracking operations will continue during a pause.

Examples:
`curl http://geogdo-ip:8555/pause?duration=10` - pauses garage door operations for 10 seconds
`curl http://geogdo-ip:8555/pause` - pauses indefinitely
`curl http://geogdo-ip:8555/resume` - resumes garage door operations