### PR TITLE
feat: add restricted zone to poly geo

### DIFF
--- a/examples/config.polygon.http.yml
+++ b/examples/config.polygon.http.yml
@@ -51,6 +51,17 @@ garage_doors:
             lng: -123.79950958978756
           - lat: 46.192958467582514
             lng: -123.7998033090239
+        restricted: # when a vehicle moves into an open geofence or out of a close geofence __from or while in a restricted zone__, no action will trigger
+          - lat: 46.192958467582514
+            lng: -123.7998033090239
+          - lat: 46.19279440766502
+            lng: -123.7998033090239
+          - lat: 46.19279440766502
+            lng: -123.79950958978756
+          - lat: 46.192958467582514
+            lng: -123.79950958978756
+          - lat: 46.192958467582514
+            lng: -123.7998033090239
     opener:  # defines how to control the garage
       type: http # type of garage door opener to use
       settings:

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -19,21 +19,22 @@ type (
 	}
 
 	Tracker struct {
-		ID                  interface{} `yaml:"id"` // mqtt identifier for vehicle
-		GarageDoor          *GarageDoor // bidirectional pointer to GarageDoor containing tracker
-		CurrentLocation     Point       // current vehicle location
-		LocationUpdate      chan Point  // channel to receive location updates
-		CurDistance         float64     // current distance from garagedoor location
-		PrevGeofence        string      // geofence previously ascribed to tracker
-		CurGeofence         string      // updated geofence ascribed to tracker when published to mqtt
-		InsidePolyOpenGeo   bool        // indicates if tracker is currently inside the polygon_open_geofence
-		InsidePolyCloseGeo  bool        // indicates if tracker is currently inside the polygon_close_geofence
-		LastEnteredCloseGeo time.Time   // timestamp of when tracker last entered the close geofence; used to prevent flapping
-		LastLeftOpenGeo     time.Time   // timestamp of when tracker last left the open geofence; used to prevent flapping
-		LatTopic            string      `yaml:"lat_topic"`
-		LngTopic            string      `yaml:"lng_topic"`
-		GeofenceTopic       string      `yaml:"geofence_topic"` // topic for publishing a geofence name where a tracker resides, e.g. teslamate geofence indicating 'home' or 'not_home'
-		ComplexTopic        struct {
+		ID                      interface{} `yaml:"id"` // mqtt identifier for vehicle
+		GarageDoor              *GarageDoor // bidirectional pointer to GarageDoor containing tracker
+		CurrentLocation         Point       // current vehicle location
+		LocationUpdate          chan Point  // channel to receive location updates
+		CurDistance             float64     // current distance from garagedoor location
+		PrevGeofence            string      // geofence previously ascribed to tracker
+		CurGeofence             string      // updated geofence ascribed to tracker when published to mqtt
+		InsidePolyOpenGeo       bool        // indicates if tracker is currently inside the polygon_open_geofence
+		InsidePolyCloseGeo      bool        // indicates if tracker is currently inside the polygon_close_geofence
+		InsidePolyRestrictedGeo bool        // indicates if tracker is currently inside the polygon_restricted_geofence
+		LastEnteredCloseGeo     time.Time   // timestamp of when tracker last entered the close geofence; used to prevent flapping
+		LastLeftOpenGeo         time.Time   // timestamp of when tracker last left the open geofence; used to prevent flapping
+		LatTopic                string      `yaml:"lat_topic"`
+		LngTopic                string      `yaml:"lng_topic"`
+		GeofenceTopic           string      `yaml:"geofence_topic"` // topic for publishing a geofence name where a tracker resides, e.g. teslamate geofence indicating 'home' or 'not_home'
+		ComplexTopic            struct {
 			Topic      string `yaml:"topic"`
 			LatJsonKey string `yaml:"lat_json_key"`
 			LngJsonKey string `yaml:"lng_json_key"`

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -265,6 +265,36 @@ func Test_CheckPolyGeofence_Arriving(t *testing.T) {
 	assert.Equal(t, checkGeofenceWrapper(polygonTracker), true)
 }
 
+// if arriving from a restricted area, should not trigger any action
+func Test_CheckPolyGeofence_ArrivingFromRestricted(t *testing.T) {
+	mockGdo := &mocks.GDO{}
+	polygonTracker.GarageDoor.Opener = mockGdo
+	defer mockGdo.AssertExpectations(t)
+
+	polygonTracker.InsidePolyCloseGeo = false
+	polygonTracker.InsidePolyOpenGeo = false
+	polygonTracker.InsidePolyRestrictedGeo = true
+	polygonTracker.CurrentLocation.Lat = 46.19243683948096
+	polygonTracker.CurrentLocation.Lng = -123.80103692981524
+
+	assert.Equal(t, checkGeofenceWrapper(polygonTracker), true)
+}
+
+// if leaving from a restricted area, should not trigger any action
+func Test_CheckPolyGeofence_LeavingFromRestricted(t *testing.T) {
+	mockGdo := &mocks.GDO{}
+	polygonTracker.GarageDoor.Opener = mockGdo
+	defer mockGdo.AssertExpectations(t)
+
+	polygonTracker.InsidePolyCloseGeo = true
+	polygonTracker.InsidePolyOpenGeo = true
+	polygonTracker.InsidePolyRestrictedGeo = true
+	polygonTracker.CurrentLocation.Lat = 46.19292902096646
+	polygonTracker.CurrentLocation.Lng = -123.79984989897177
+
+	assert.Equal(t, checkGeofenceWrapper(polygonTracker), true)
+}
+
 // if close is not defined, should not trigger any action
 func Test_CheckPolyGeofence_Leaving_NoClose(t *testing.T) {
 	mockGdo := &mocks.GDO{}

--- a/resources/polygon_map.kml
+++ b/resources/polygon_map.kml
@@ -40,13 +40,30 @@
       </Polygon>
     </Placemark>
     <Placemark id="2">
+      <name>restricted</name>
+      <ExtendedData></ExtendedData>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>
+              -123.7998033090239,46.192958467582514
+              -123.7998033090239,46.19279440766502
+              -123.79950958978756,46.19279440766502
+              -123.79950958978756,46.192958467582514
+              -123.7998033090239,46.192958467582514
+            </coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+    <Placemark id="3">
       <name>close_test</name>
       <ExtendedData></ExtendedData>
       <Point>
         <coordinates>-123.79984989897177,46.19292902096646</coordinates>
       </Point>
     </Placemark>
-    <Placemark id="3">
+    <Placemark id="4">
       <name>open_test</name>
       <ExtendedData></ExtendedData>
       <Point>


### PR DESCRIPTION
Adds an option to create a restricted zone for polygon geofences. If a tracker enters an open geofence or leaves a close geofence *while in or coming from a restricted zone*, then no action will trigger.