### PR TITLE
feat: allow duplicate trackers

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -202,7 +202,7 @@ func main() {
 					t.CurGeofence = string(message.Payload())
 					logger.Infof("Received geo for tracker %v: %s", t.ID, t.CurGeofence)
 					go geo.CheckGeofence(t)
-					break topic
+					// break topic
 				case t.ComplexTopic.Topic:
 					logger.Debugf("Received payload for complex topic %s for tracker %v, payload:\n%s", message.Topic(), t.ID, string(message.Payload()))
 					point, err = processComplexTopicPayload(t, string(message.Payload()))
@@ -212,16 +212,16 @@ func main() {
 
 				if err != nil {
 					logger.Errorf("could not parse message payload from topic for tracker %v, received error %v", t.ID, err)
-					break topic
+					// break topic
 				}
 
 				// if a point is now defined, process a location update and stop looking for matching topics
 				if point != (geo.Point{}) {
-					go func(p geo.Point) {
+					go func(p geo.Point, t *geo.Tracker) {
 						// send as goroutine so it doesn't block other vehicle updates if channel buffer is full
-						t.LocationUpdate <- point
-					}(point)
-					break topic
+						t.LocationUpdate <- p
+					}(point, t)
+					// break topic
 				}
 			}
 


### PR DESCRIPTION
### Summary

Allow duplicate trackers

### Context

There may be scenarios where a user wishes to control multiple doors with a single tracker (vehicle), but currently when a topic message is consumed, the code looks for the first matching tracker and then breaks, so any other doors with the same tracker value would never execute. This removes the breaks to search through all trackers for a match.