### PR TITLE
fix: fatal error logging

### DIFF
--- a/internal/gdo/mqtt/mqtt_test.go
+++ b/internal/gdo/mqtt/mqtt_test.go
@@ -106,7 +106,7 @@ func Test_InitializeClient(t *testing.T) {
 	mockMqttClient.EXPECT().IsConnected().Once().Return(true)
 
 	// override mqtt.NewClient function with mocked function
-	mqttNewClientFunc = func(o *mqtt.ClientOptions) mqtt.Client { return mockMqttClient }
+	mqttNewClientFunc = func(_ *mqtt.ClientOptions) mqtt.Client { return mockMqttClient }
 
 	// initialize test object
 	mqttGdo := &mqttGdo{}

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -55,9 +55,14 @@ func formatLevel(level logger.Level) string {
 		"DEBUG":   "DBG",
 		"ERROR":   "ERR",
 		"TRACE":   "TRC",
+		"FATAL":   "FTL",
 	}
 
-	return " " + displayMap[strings.ToUpper(fmt.Sprintf("%v", level))] + " "
+	displayLevel, ok := displayMap[strings.ToUpper(fmt.Sprintf("%v", level))]
+	if !ok {
+		displayLevel = strings.ToUpper(fmt.Sprintf("%v", level))
+	}
+	return " " + displayLevel + " "
 }
 
 // custom formatter for logrus package


### PR DESCRIPTION
### Summary

Add an entry to the log level format map for fatal errors, and add a fallback default if an unknown log level is sent.