### PR TITLE
feat: allow disable preflight check ratdgo

### DIFF
--- a/examples/config.circular.ratgdo.yml
+++ b/examples/config.circular.ratgdo.yml
@@ -38,6 +38,7 @@ garage_doors:
           use_tls: false # optional, instructs app to connect to mqtt broker using tls (defaults to false)
           skip_tls_verify: false # optional, if use_tls = true, this option indicates whether the client should skip certificate validation on the mqtt broker
         topic_prefix: home/garage/Main # required
+        disable_required_start_state_check: true # optional, disables the requirement that the garage door must be in a specific state before operating (e.g. closed) to prevent accidental operations
     trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker

--- a/examples/config.multiple.yml
+++ b/examples/config.multiple.yml
@@ -33,6 +33,8 @@ garage_doors:
           client_id: tesla-geogdo-ratgdo1
           # WARNING!! client_id's MUST BE UNIQUE for any mqtt client that shares a broker !!
         topic_prefix: home/garage/Main
+      settings:
+        disable_required_start_state_check: true
     trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker

--- a/examples/config.multiple.yml
+++ b/examples/config.multiple.yml
@@ -33,8 +33,6 @@ garage_doors:
           client_id: tesla-geogdo-ratgdo1
           # WARNING!! client_id's MUST BE UNIQUE for any mqtt client that shares a broker !!
         topic_prefix: home/garage/Main
-      settings:
-        disable_required_start_state_check: true
     trackers: # defines which trackers should be used to operate garage; list of trackers includes an arbitrary (but unique) id and topic definitions to retrieve latitude and longitude
       - id: 1 # required, some identifier, can be number or string
         lat_topic: teslamate/cars/1/latitude # topic to retrieve latitude for tracker

--- a/internal/gdo/ratgdo/ratgdo.go
+++ b/internal/gdo/ratgdo/ratgdo.go
@@ -15,6 +15,9 @@ type Ratgdo struct {
 	MqttSettings struct {
 		TopicPrefix string `yaml:"topic_prefix"`
 	} `yaml:"mqtt_settings"`
+	Settings struct {
+		DisableRequiredStartStateCheck bool `yaml:"disable_required_start_state_check"`
+	} `yaml:"settings"`
 }
 
 func init() {
@@ -70,6 +73,13 @@ func NewRatgdo(config map[string]interface{}) (mqttGdo.MqttGdo, error) {
 				"required_start_state":  "open",
 				"required_finish_state": "closed",
 			},
+		}
+
+		if ratgdo.Settings.DisableRequiredStartStateCheck {
+			// remove the required_start_state field from all commands
+			for _, command := range mqttSettings["commands"].([]map[string]string) {
+				delete(command, "required_start_state")
+			}
 		}
 	}
 

--- a/internal/gdo/ratgdo/ratgdo.go
+++ b/internal/gdo/ratgdo/ratgdo.go
@@ -13,11 +13,9 @@ import (
 // stubbed mqtt struct to extract the topic prefix from the yaml to pass into what is expected by mqttGdo
 type Ratgdo struct {
 	MqttSettings struct {
-		TopicPrefix string `yaml:"topic_prefix"`
+		TopicPrefix                    string `yaml:"topic_prefix"`
+		DisableRequiredStartStateCheck bool   `yaml:"disable_required_start_state_check"`
 	} `yaml:"mqtt_settings"`
-	Settings struct {
-		DisableRequiredStartStateCheck bool `yaml:"disable_required_start_state_check"`
-	} `yaml:"settings"`
 }
 
 func init() {
@@ -75,7 +73,7 @@ func NewRatgdo(config map[string]interface{}) (mqttGdo.MqttGdo, error) {
 			},
 		}
 
-		if ratgdo.Settings.DisableRequiredStartStateCheck {
+		if ratgdo.MqttSettings.DisableRequiredStartStateCheck {
 			// remove the required_start_state field from all commands
 			for _, command := range mqttSettings["commands"].([]map[string]string) {
 				delete(command, "required_start_state")

--- a/internal/gdo/ratgdo/ratgdo_test.go
+++ b/internal/gdo/ratgdo/ratgdo_test.go
@@ -21,6 +21,9 @@ var sampleYaml = map[string]interface{}{
 		},
 		"topic_prefix": "home/garage/Main",
 	},
+	"settings": map[string]interface{}{
+		"disable_required_start_state_check": true,
+	},
 }
 
 // Since ratgdo is just a wrapper for mqttGdo with some predefined configs,

--- a/internal/gdo/ratgdo/ratgdo_test.go
+++ b/internal/gdo/ratgdo/ratgdo_test.go
@@ -19,9 +19,7 @@ var sampleYaml = map[string]interface{}{
 			"use_tls":         false,
 			"skip_tls_verify": false,
 		},
-		"topic_prefix": "home/garage/Main",
-	},
-	"settings": map[string]interface{}{
+		"topic_prefix":                       "home/garage/Main",
 		"disable_required_start_state_check": true,
 	},
 }


### PR DESCRIPTION
### Summary

Allow disabling preflight check for ratgdo operations.

### Context

Generic openers like `mqtt` and `http` have an optional yaml key `required_start_state`. If omitted, the opener will _always_ send the command without checking for a current garage door state. `ratgdo` opener uses `mqtt` under the hood and is just a wrapper, but always sets the `required_start_state` key. This change will allow omitting that key from the wrapper so a user can decide if they care about the preflight check or not.